### PR TITLE
fix: remove superfluous to_pandas wrapper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ good_fits = results.filter(ks_threshold=0.05)        # K-S statistic < 0.05
 significant = results.filter(pvalue_threshold=0.05)  # p-value > 0.05
 
 # Convert to pandas for analysis
-df_pandas = results.to_pandas()
+df_pandas = results.df.toPandas()
 
 # Use fitted distribution
 samples = best.sample(size=10000)  # Generate samples

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -102,7 +102,7 @@ Working with Results
    significant = results.filter(pvalue_threshold=0.05)  # p-value > 0.05
 
    # Convert to pandas for analysis
-   df_pandas = results.to_pandas()
+   df_pandas = results.df.toPandas()
 
    # Use fitted distribution
    samples = best.sample(size=10000)  # Generate samples

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -224,12 +224,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Convert to pandas DataFrame for further analysis\n",
-    "df_results = results_normal.to_pandas()\n",
-    "print(\"Results as pandas DataFrame:\")\n",
-    "df_results.head(10)"
-   ]
+   "source": "# Convert to pandas DataFrame for further analysis\ndf_results = results_normal.df.toPandas()\nprint(\"Results as pandas DataFrame:\")\ndf_results.head(10)"
   },
   {
    "cell_type": "markdown",
@@ -358,7 +353,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Complete workflow with all parameters\nfitter_gamma = DistributionFitter(spark, random_seed=42)\n\n# Fit distributions\nprint(\"Fitting gamma distribution data...\")\nresults = fitter_gamma.fit(\n    df_gamma,\n    column=\"value\",\n    bins=100,\n    use_rice_rule=False,\n    enable_sampling=True,\n    max_sample_size=1_000_000,\n    max_distributions=25,\n)\n\n# Get best result\nbest = results.best(n=1)[0]\nprint(f\"\\nBest distribution: {best.distribution}\")\nprint(f\"K-S statistic: {best.ks_statistic:.6f}\")\nprint(f\"p-value: {best.pvalue:.4f}\")\nprint(f\"SSE: {best.sse:.6f}\")\nprint(f\"Parameters: {[f'{p:.4f}' for p in best.parameters]}\")\n\n# Plot with custom parameters\nfig, ax = fitter_gamma.plot(\n    best,\n    df_gamma,\n    \"value\",\n    figsize=(14, 9),\n    dpi=150,\n    histogram_alpha=0.6,\n    pdf_linewidth=3,\n    title_fontsize=16,\n    title=f\"Gamma Data - Best Fit: {best.distribution.capitalize()}\",\n    xlabel=\"Value\",\n    ylabel=\"Density\",\n)\nplt.show()\n\n# Show top 5 results\nprint(\"\\nTop 5 distributions:\")\ndf_top5 = results.to_pandas().head(5)\ndf_top5[[\"distribution\", \"ks_statistic\", \"pvalue\", \"sse\", \"aic\", \"bic\"]]"
+   "source": "# Complete workflow with all parameters\nfitter_gamma = DistributionFitter(spark, random_seed=42)\n\n# Fit distributions\nprint(\"Fitting gamma distribution data...\")\nresults = fitter_gamma.fit(\n    df_gamma,\n    column=\"value\",\n    bins=100,\n    use_rice_rule=False,\n    enable_sampling=True,\n    max_sample_size=1_000_000,\n    max_distributions=25,\n)\n\n# Get best result\nbest = results.best(n=1)[0]\nprint(f\"\\nBest distribution: {best.distribution}\")\nprint(f\"K-S statistic: {best.ks_statistic:.6f}\")\nprint(f\"p-value: {best.pvalue:.4f}\")\nprint(f\"SSE: {best.sse:.6f}\")\nprint(f\"Parameters: {[f'{p:.4f}' for p in best.parameters]}\")\n\n# Plot with custom parameters\nfig, ax = fitter_gamma.plot(\n    best,\n    df_gamma,\n    \"value\",\n    figsize=(14, 9),\n    dpi=150,\n    histogram_alpha=0.6,\n    pdf_linewidth=3,\n    title_fontsize=16,\n    title=f\"Gamma Data - Best Fit: {best.distribution.capitalize()}\",\n    xlabel=\"Value\",\n    ylabel=\"Density\",\n)\nplt.show()\n\n# Show top 5 results\nprint(\"\\nTop 5 distributions:\")\ndf_top5 = results.df.toPandas().head(5)\ndf_top5[[\"distribution\", \"ks_statistic\", \"pvalue\", \"sse\", \"aic\", \"bic\"]]"
   },
   {
    "cell_type": "markdown",
@@ -382,7 +377,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Excluded Distributions**:\n   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n\n2. **SparkSession Management**:\n   - You create and configure your own SparkSession\n   - Pass it to `DistributionFitter(spark)` or use active session\n\n3. **Fitting**:\n   - `DistributionFitter.fit()` - Fit distributions to data\n   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n   - `max_distributions` parameter to limit fitting scope\n\n4. **Results**:\n   - `results.best(n, metric)` - Get top N by K-S statistic (default), SSE, AIC, or BIC\n   - `results.filter(ks_threshold, pvalue_threshold)` - Filter by goodness-of-fit\n   - `results.to_pandas()` - Convert to pandas DataFrame\n   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n\n5. **Plotting**:\n   - `fitter.plot()` - Visualize fitted distribution with data histogram\n   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n\n6. **Goodness-of-Fit Metrics**:\n   - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n   - **p-value** - Higher is better (>0.05 suggests good fit)\n   - **SSE** - Sum of squared errors between histogram and fitted PDF\n   - **AIC/BIC** - Information criteria for model comparison"
+   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Excluded Distributions**:\n   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n\n2. **SparkSession Management**:\n   - You create and configure your own SparkSession\n   - Pass it to `DistributionFitter(spark)` or use active session\n\n3. **Fitting**:\n   - `DistributionFitter.fit()` - Fit distributions to data\n   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n   - `max_distributions` parameter to limit fitting scope\n\n4. **Results**:\n   - `results.best(n, metric)` - Get top N by K-S statistic (default), SSE, AIC, or BIC\n   - `results.filter(ks_threshold, pvalue_threshold)` - Filter by goodness-of-fit\n   - `results.df.toPandas()` - Convert to pandas DataFrame\n   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n\n5. **Plotting**:\n   - `fitter.plot()` - Visualize fitted distribution with data histogram\n   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n\n6. **Goodness-of-Fit Metrics**:\n   - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n   - **p-value** - Higher is better (>0.05 suggests good fit)\n   - **SSE** - Sum of squared errors between histogram and fitted PDF\n   - **AIC/BIC** - Information criteria for model comparison"
   }
  ],
  "metadata": {

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -210,11 +210,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Convert all results to pandas DataFrame for further analysis\n",
-    "results_df = results.to_pandas()\n",
-    "results_df.head(10)"
-   ]
+   "source": "# Convert all results to pandas DataFrame for further analysis\nresults_df = results.df.toPandas()\nresults_df.head(10)"
   },
   {
    "cell_type": "markdown",

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -153,7 +153,7 @@ class FitResults:
         >>> # Get top 5 by AIC
         >>> top_aic = results.best(n=5, metric='aic')
         >>> # Convert to pandas for analysis
-        >>> df_pandas = results.to_pandas()
+        >>> df_pandas = results.df.toPandas()
         >>> # Filter by SSE threshold
         >>> good_fits = results.filter(sse_threshold=0.01)
     """
@@ -165,14 +165,6 @@ class FitResults:
             results_df: Spark DataFrame with fit results
         """
         self._df = results_df
-
-    def to_pandas(self) -> pd.DataFrame:
-        """Convert results to pandas DataFrame.
-
-        Returns:
-            Pandas DataFrame with all results
-        """
-        return self._df.toPandas()
 
     @property
     def df(self) -> DataFrame:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,7 +71,7 @@ class TestDistributionFitter:
 
         # All distributions should be non-negative
         registry = DistributionRegistry()
-        df_pandas = results.to_pandas()
+        df_pandas = results.df.toPandas()
         for dist_name in df_pandas["distribution"]:
             assert registry._has_support_at_zero(dist_name) is True
 
@@ -168,8 +168,8 @@ class TestDistributionFitter:
         assert best1.parameters == best2.parameters
 
         # DataFrame should also be consistent
-        df1 = results.to_pandas()
-        df2 = results.to_pandas()
+        df1 = results.df.toPandas()
+        df2 = results.df.toPandas()
         assert len(df1) == len(df2)
         assert list(df1["distribution"]) == list(df2["distribution"])
 
@@ -179,7 +179,7 @@ class TestDistributionFitter:
         results = fitter.fit(small_dataset, column="value", max_distributions=5)
 
         # All results should have finite SSE
-        df_pandas = results.to_pandas()
+        df_pandas = results.df.toPandas()
         assert all(np.isfinite(df_pandas["sse"]))
 
     def test_fit_with_constant_data(self, spark_session, constant_dataset):
@@ -192,7 +192,7 @@ class TestDistributionFitter:
         # Returns valid FitResults (may have 0 or more distributions)
         assert isinstance(results, FitResults)
         # Verify we can call methods on it without error
-        _ = results.to_pandas()
+        _ = results.df.toPandas()
 
     def test_fit_with_rice_rule(self, spark_session, small_dataset):
         """Test fitting with Rice rule for bins."""
@@ -208,7 +208,7 @@ class TestDistributionFitter:
         results = fitter.fit(small_dataset, column="value", max_distributions=5)
 
         # norm and expon should not be in results
-        df_pandas = results.to_pandas()
+        df_pandas = results.df.toPandas()
         assert "norm" not in df_pandas["distribution"].values
         assert "expon" not in df_pandas["distribution"].values
 
@@ -317,7 +317,7 @@ class TestEdgeCases:
 
         # Returns valid FitResults
         assert isinstance(results, FitResults)
-        _ = results.to_pandas()
+        _ = results.df.toPandas()
 
     def test_single_value_dataset(self, spark_session):
         """Test with single value."""
@@ -330,7 +330,7 @@ class TestEdgeCases:
 
         # Returns valid FitResults
         assert isinstance(results, FitResults)
-        _ = results.to_pandas()
+        _ = results.df.toPandas()
 
     def test_dataset_with_outliers(self, spark_session):
         """Test with dataset containing extreme outliers."""

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -154,10 +154,10 @@ class TestFitResults:
 
         assert results._df == sample_results_df
 
-    def test_to_pandas(self, sample_results_df):
-        """Test converting to pandas DataFrame."""
+    def test_df_to_pandas(self, sample_results_df):
+        """Test converting to pandas DataFrame via df property."""
         results = FitResults(sample_results_df)
-        df_pandas = results.to_pandas()
+        df_pandas = results.df.toPandas()
 
         assert len(df_pandas) == 5
         assert "distribution" in df_pandas.columns
@@ -231,7 +231,7 @@ class TestFitResults:
         filtered = results.filter(**threshold_kwarg)
 
         assert filtered.count() == expected_count
-        df_pandas = filtered.to_pandas()
+        df_pandas = filtered.df.toPandas()
         assert all(df_pandas[threshold_val] < list(threshold_kwarg.values())[0])
 
     def test_filter_by_pvalue_threshold(self, sample_results_df):
@@ -241,7 +241,7 @@ class TestFitResults:
         filtered = results.filter(pvalue_threshold=0.80)
 
         assert filtered.count() == 3
-        df_pandas = filtered.to_pandas()
+        df_pandas = filtered.df.toPandas()
         assert all(df_pandas["pvalue"] > 0.80)
 
     def test_filter_multiple_criteria(self, sample_results_df):
@@ -250,7 +250,7 @@ class TestFitResults:
         filtered = results.filter(sse_threshold=0.010, aic_threshold=1600)
 
         # Should meet both criteria
-        df_pandas = filtered.to_pandas()
+        df_pandas = filtered.df.toPandas()
         assert all(df_pandas["sse"] < 0.010)
         assert all(df_pandas["aic"] < 1600)
 


### PR DESCRIPTION
## Summary
- Removed the redundant `to_pandas()` method from `FitResults` class
- Users can now use `results.df.toPandas()` directly via the existing `df` property
- Updated all code references, tests, documentation, and examples

## Rationale
The `to_pandas()` method was just a thin wrapper around `self._df.toPandas()`. Since the `df` property already exposes the underlying Spark DataFrame, this method was unnecessary.