### PR TITLE
chore: align docs and tests with ks_statistic default metric

### DIFF
--- a/src/spark_bestfit/__init__.py
+++ b/src/spark_bestfit/__init__.py
@@ -15,9 +15,9 @@ Example:
     >>> fitter = DistributionFitter(spark)
     >>> results = fitter.fit(df, column='value')
     >>>
-    >>> # Get best distribution
+    >>> # Get best distribution (by K-S statistic, the default)
     >>> best = results.best(n=1)[0]
-    >>> print(f"Best: {best.distribution} with SSE={best.sse:.6f}")
+    >>> print(f"Best: {best.distribution} with KS={best.ks_statistic:.6f}")
     >>>
     >>> # Plot
     >>> fitter.plot(best, df, 'value', title='Best Fit Distribution')

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -302,5 +302,8 @@ class FitResults:
         count = self.count()
         if count > 0:
             best = self.best(n=1)[0]
-            return f"FitResults({count} distributions fitted, " f"best: {best.distribution} with SSE={best.sse:.6f})"
+            return (
+                f"FitResults({count} distributions fitted, "
+                f"best: {best.distribution} with KS={best.ks_statistic:.6f})"
+            )
         return f"FitResults({count} distributions fitted)"

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -101,7 +101,7 @@ class TestHistogramComputer:
         # Should have at most len(bin_edges) - 1 rows (some bins may be empty)
         assert histogram_df.count() <= len(bin_edges) - 1
 
-    def test_compute_statistics(self, spark_session, normal_data, small_dataset):
+    def test_compute_statistics(self, spark_session, small_dataset):
         """Test computing basic statistics."""
         computer = HistogramComputer()
         stats = computer.compute_statistics(small_dataset, "value")
@@ -120,7 +120,7 @@ class TestHistogramComputer:
         assert stats["stddev"] is not None
         assert 8 < stats["stddev"] < 12  # Close to 10
 
-        assert stats["count"] == len(normal_data)
+        assert stats["count"] == small_dataset.count()
 
     def test_compute_statistics_types(self, spark_session, small_dataset):
         """Test that statistics are returned as floats."""

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -290,7 +290,7 @@ class TestFitResults:
 
         assert "5 distributions" in repr_str
         assert "gamma" in repr_str  # Best distribution
-        assert "0.003" in repr_str  # Best SSE
+        assert "0.020" in repr_str  # Best KS statistic
 
     def test_empty_results(self, spark_session):
         """Test FitResults with empty DataFrame handles all operations gracefully."""


### PR DESCRIPTION
## Summary
   - Update  example to show KS statistic instead of SSE
   - Update  to display KS statistic (matches default metric)
   - Fix : remove unused  fixture
   - Fix : check for KS statistic in repr test