### PR TITLE
perf: optimize Spark actions in plot_qq and filter

### DIFF
--- a/src/spark_bestfit/core.py
+++ b/src/spark_bestfit/core.py
@@ -453,11 +453,9 @@ class DistributionFitter:
         """
         from spark_bestfit.plotting import plot_qq
 
-        # Sample data for Q-Q plot
-        row_count = df.count()
-        sample_size = min(max_points, row_count)
-        fraction = min(sample_size / row_count, 1.0)
-        sample_df = df.select(column).sample(fraction=fraction, seed=self.random_seed)
+        # Sample data for Q-Q plot without requiring count()
+        # orderBy(rand()) + limit() avoids expensive count() operation
+        sample_df = df.select(column).orderBy(F.rand(seed=self.random_seed)).limit(max_points)
         data = sample_df.toPandas()[column].values
 
         return plot_qq(

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -254,7 +254,7 @@ class FitResults:
         if pvalue_threshold is not None:
             filtered = filtered.filter(F.col("pvalue") > pvalue_threshold)
 
-        return FitResults(filtered)
+        return FitResults(filtered.cache())
 
     def summary(self) -> pd.DataFrame:
         """Get summary statistics of fit quality.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -302,6 +302,29 @@ class TestDistributionFitterPlotting:
         assert fig is not None
         assert ax is not None
 
+    def test_plot_qq_after_fit(self, spark_session, small_dataset):
+        """Test Q-Q plotting after fitting."""
+        fitter = DistributionFitter(spark_session)
+        results = fitter.fit(small_dataset, column="value", max_distributions=5)
+        best = results.best(n=1)[0]
+
+        fig, ax = fitter.plot_qq(best, small_dataset, "value")
+
+        assert fig is not None
+        assert ax is not None
+
+    def test_plot_qq_with_max_points(self, spark_session, small_dataset):
+        """Test Q-Q plotting with custom max_points."""
+        fitter = DistributionFitter(spark_session)
+        results = fitter.fit(small_dataset, column="value", max_distributions=5)
+        best = results.best(n=1)[0]
+
+        fig, ax = fitter.plot_qq(best, small_dataset, "value", max_points=500, title="Q-Q Test")
+
+        assert fig is not None
+        assert ax is not None
+
+
 class TestEdgeCases:
     """Tests for edge cases and error handling."""
 


### PR DESCRIPTION
## Summary
- Remove redundant `df.count()` in `plot_qq`, use `orderBy(rand()).limit()` instead
- Cache filtered DataFrame in `FitResults.filter()` to prevent recomputation
- Add integration tests for `DistributionFitter.plot_qq()`