### PR TITLE
chore: fix repo-stats action version

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run github-repo-stats
-        uses: jgehrcke/github-repo-stats@v1
+        uses: jgehrcke/github-repo-stats@RELEASE
         with:
           ghtoken: ${{ secrets.REPO_STATS_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Use `@RELEASE` tag instead of non-existent `@v1`