### PR TITLE
chore: add docs and test coverage for priority items

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,7 +92,38 @@ Pass parameters directly to ``fit()`` to customize behavior:
        enable_sampling=True,        # Enable adaptive sampling
        sample_fraction=0.3,         # Sample 30% of data
        max_distributions=50,        # Limit distributions to fit
+       num_partitions=16,           # Spark parallelism (None = auto)
    )
+
+Parallelism Control
+-------------------
+
+The ``num_partitions`` parameter controls how many Spark partitions are used for parallel
+distribution fitting. Each partition fits a subset of distributions independently.
+
+**Default behavior (num_partitions=None):**
+
+The library auto-calculates partitions using: ``min(num_distributions, 2 × defaultParallelism)``
+
+- ``num_distributions``: Number of distributions being fitted
+- ``defaultParallelism``: Spark's default parallelism (typically equals total executor cores)
+
+**When to override:**
+
+.. code-block:: python
+
+   # Large cluster with many executors - increase parallelism
+   results = fitter.fit(df, "value", num_partitions=64)
+
+   # Resource-constrained environment - reduce parallelism
+   results = fitter.fit(df, "value", num_partitions=4)
+
+   # Fitting few distributions - let auto-calculate handle it
+   results = fitter.fit(df, "value", max_distributions=10)  # num_partitions auto-set
+
+.. note::
+   Setting ``num_partitions`` higher than the number of distributions has no benefit,
+   as each distribution requires exactly one task.
 
 Working with Results
 --------------------

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -234,6 +234,54 @@ class TestPlotComparison:
         assert fig is not None
         plt.close(fig)
 
+    def test_comparison_custom_axis_labels(self, normal_result, gamma_result, sample_histogram):
+        """Test comparison with custom axis labels."""
+        y_hist, x_hist = sample_histogram
+
+        fig, ax = plot_comparison(
+            [normal_result, gamma_result],
+            y_hist,
+            x_hist,
+            xlabel="Custom X Label",
+            ylabel="Custom Y Label",
+        )
+
+        assert ax.get_xlabel() == "Custom X Label"
+        assert ax.get_ylabel() == "Custom Y Label"
+        plt.close(fig)
+
+    def test_comparison_custom_figsize(self, normal_result, sample_histogram):
+        """Test comparison with custom figure size."""
+        y_hist, x_hist = sample_histogram
+
+        fig, ax = plot_comparison(
+            [normal_result],
+            y_hist,
+            x_hist,
+            figsize=(16, 12),
+        )
+
+        width, height = fig.get_size_inches()
+        assert width == 16
+        assert height == 12
+        plt.close(fig)
+
+    def test_comparison_save_pdf_format(self, normal_result, gamma_result, sample_histogram, tmp_path):
+        """Test saving comparison plot as PDF."""
+        y_hist, x_hist = sample_histogram
+        save_path = str(tmp_path / "comparison.pdf")
+
+        fig, ax = plot_comparison(
+            [normal_result, gamma_result],
+            y_hist,
+            x_hist,
+            save_path=save_path,
+            save_format="pdf",
+        )
+
+        assert (tmp_path / "comparison.pdf").exists()
+        plt.close(fig)
+
 
 class TestPlotSaving:
     """Tests for plot saving functionality."""


### PR DESCRIPTION
## Summary

- Document `num_partitions` parameter in quickstart.rst with new "Parallelism Control" section explaining auto-calculation formula
- Add `plot_comparison()` tests for custom labels, figsize, and PDF format
- Add broadcast cleanup tests verifying `unpersist()` is called