### PR TITLE
feat: add bootstrap confidence intervals for fitted parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Efficiently fit ~100 scipy.stats distributions to your data using Spark's parall
 - **Histogram-Based Fitting**: Efficient fitting using histogram representation
 - **Multiple Metrics**: Compare fits using K-S statistic, A-D statistic, SSE, AIC, and BIC
 - **Statistical Validation**: Kolmogorov-Smirnov and Anderson-Darling tests for goodness-of-fit
+- **Confidence Intervals**: Bootstrap confidence intervals for fitted parameters
 - **Results API**: Filter, sort, and export results easily
 - **Visualization**: Built-in plotting for distribution comparison, Q-Q plots and P-P plots
 - **Flexible Configuration**: Customize bins, sampling, and distribution selection
@@ -124,6 +125,18 @@ print(f"A-D: {best.ad_statistic}, A-D p-value: {best.ad_pvalue}")
 > **Note**: Anderson-Darling p-values are only available for 5 distributions (norm, expon,
 > logistic, gumbel_r, gumbel_l) where scipy has critical value tables. For other distributions,
 > `ad_pvalue` will be `None` but `ad_statistic` is still valid for ranking fits.
+
+### Parameter Confidence Intervals
+
+```python
+# Compute 95% bootstrap confidence intervals
+ci = best.confidence_intervals(df, column="value", alpha=0.05, n_bootstrap=1000, random_seed=42)
+
+# Display with parameter names
+print(f"Distribution: {best.distribution}")
+for param, (lower, upper) in ci.items():
+    print(f"  {param}: [{lower:.4f}, {upper:.4f}]")
+```
 
 ### Custom Plotting
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -155,6 +155,43 @@ Working with Results
    print(f"K-S: {best.ks_statistic}, p-value: {best.pvalue}")
    print(f"A-D: {best.ad_statistic}, A-D p-value: {best.ad_pvalue}")
 
+Parameter Confidence Intervals
+------------------------------
+
+Compute bootstrap confidence intervals for fitted distribution parameters:
+
+.. code-block:: python
+
+   # Get the best fit
+   best = results.best(n=1)[0]
+
+   # Compute 95% confidence intervals
+   ci = best.confidence_intervals(
+       df,
+       column="value",
+       alpha=0.05,              # 95% CI (default)
+       n_bootstrap=1000,        # Number of bootstrap samples
+       random_seed=42,          # For reproducibility
+   )
+
+   # Display results
+   print(f"Distribution: {best.distribution}")
+   print(f"Parameters: {best.get_param_names()}")
+   for param, (lower, upper) in ci.items():
+       print(f"  {param}: [{lower:.4f}, {upper:.4f}]")
+
+   # Example output for gamma distribution:
+   # Distribution: gamma
+   # Parameters: ['a', 'loc', 'scale']
+   #   a: [1.92, 2.15]
+   #   loc: [-0.05, 0.12]
+   #   scale: [0.98, 1.03]
+
+.. note::
+   The ``confidence_intervals()`` method automatically samples large DataFrames (default
+   max 10,000 rows) to avoid driver memory issues. Bootstrap computation can take a few
+   seconds depending on ``n_bootstrap``.
+
 Custom Plotting
 ---------------
 

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -3,16 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# spark-bestfit API Demo\n",
-    "\n",
-    "This notebook demonstrates the complete API for the `spark-bestfit` library, including:\n",
-    "\n",
-    "1. **Distribution Fitting** - Using DistributionFitter with direct parameters\n",
-    "2. **Working with Results** - FitResults and DistributionFitResult objects\n",
-    "3. **Plotting** - Visualization with customizable parameters\n",
-    "4. **Excluding Distributions** - Customizing which distributions to fit"
-   ]
+   "source": "# spark-bestfit API Demo\n\nThis notebook demonstrates the complete API for the `spark-bestfit` library, including:\n\n1. **Distribution Fitting** - Using DistributionFitter with direct parameters\n2. **Working with Results** - FitResults and DistributionFitResult objects\n3. **Confidence Intervals** - Bootstrap confidence intervals for fitted parameters\n4. **Plotting** - Visualization with customizable parameters\n5. **Excluding Distributions** - Customizing which distributions to fit"
   },
   {
    "cell_type": "markdown",
@@ -312,16 +303,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Evaluate PDF at specific points\n",
-    "x = np.array([30, 40, 50, 60, 70])\n",
-    "pdf_values = best.pdf(x)\n",
-    "cdf_values = best.cdf(x)\n",
-    "\n",
-    "print(\"PDF and CDF values:\")\n",
-    "for xi, pdf, cdf in zip(x, pdf_values, cdf_values):\n",
-    "    print(f\"  x={xi}: PDF={pdf:.6f}, CDF={cdf:.4f}\")"
-   ]
+   "source": "# Evaluate PDF at specific points\nx = np.array([30, 40, 50, 60, 70])\npdf_values = best.pdf(x)\ncdf_values = best.cdf(x)\n\nprint(\"PDF and CDF values:\")\nfor xi, pdf, cdf in zip(x, pdf_values, cdf_values):\n    print(f\"  x={xi}: PDF={pdf:.6f}, CDF={cdf:.4f}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 3.5 Parameter Confidence Intervals\n\nCompute bootstrap confidence intervals for fitted distribution parameters. This is useful for understanding the uncertainty in your parameter estimates.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Get parameter names for the fitted distribution\nprint(f\"Distribution: {best.distribution}\")\nprint(f\"Parameter names: {best.get_param_names()}\")\nprint(f\"Fitted values: {[f'{p:.4f}' for p in best.parameters]}\")\n\n# Compute 95% bootstrap confidence intervals\nprint(\"\\nComputing 95% confidence intervals (this may take a few seconds)...\")\nci = best.confidence_intervals(\n    df_normal,\n    column=\"value\",\n    alpha=0.05,           # 95% CI\n    n_bootstrap=500,      # Number of bootstrap samples (use 1000+ for production)\n    random_seed=42,       # For reproducibility\n)\n\nprint(\"\\nParameter confidence intervals:\")\nfor param, (lower, upper) in ci.items():\n    print(f\"  {param}: [{lower:.4f}, {upper:.4f}]\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -556,7 +550,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Excluded Distributions**:\n   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n\n2. **SparkSession Management**:\n   - You create and configure your own SparkSession\n   - Pass it to `DistributionFitter(spark)` or use active session\n\n3. **Fitting**:\n   - `DistributionFitter.fit()` - Fit distributions to data\n   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n   - `max_distributions` parameter to limit fitting scope\n\n4. **Results**:\n   - `results.best(n, metric)` - Get top N by K-S statistic (default), A-D statistic, SSE, AIC, or BIC\n   - `results.filter(ks_threshold, pvalue_threshold, ad_threshold)` - Filter by goodness-of-fit\n   - `results.df.toPandas()` - Convert to pandas DataFrame\n   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n\n5. **Plotting**:\n   - `fitter.plot()` - Visualize fitted distribution with data histogram\n   - `fitter.plot_qq()` - Q-Q plot for visual goodness-of-fit assessment\n   - `fitter.plot_pp()` - P-P plot for assessing fit in the center of distribution\n   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n\n6. **Goodness-of-Fit Metrics**:\n   - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n   - **A-D statistic** - Lower is better, more sensitive to tails than K-S\n   - **p-value** - Higher is better (>0.05 suggests good fit)\n   - **A-D p-value** - Only available for norm, expon, logistic, gumbel_r, gumbel_l\n   - **SSE** - Sum of squared errors between histogram and fitted PDF\n   - **AIC/BIC** - Information criteria for model comparison"
+   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Excluded Distributions**:\n   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n\n2. **SparkSession Management**:\n   - You create and configure your own SparkSession\n   - Pass it to `DistributionFitter(spark)` or use active session\n\n3. **Fitting**:\n   - `DistributionFitter.fit()` - Fit distributions to data\n   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n   - `max_distributions` parameter to limit fitting scope\n\n4. **Results**:\n   - `results.best(n, metric)` - Get top N by K-S statistic (default), A-D statistic, SSE, AIC, or BIC\n   - `results.filter(ks_threshold, pvalue_threshold, ad_threshold)` - Filter by goodness-of-fit\n   - `results.df.toPandas()` - Convert to pandas DataFrame\n   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n   - `DistributionFitResult.get_param_names()` - Get parameter names\n   - `DistributionFitResult.confidence_intervals()` - Bootstrap confidence intervals\n\n5. **Plotting**:\n   - `fitter.plot()` - Visualize fitted distribution with data histogram\n   - `fitter.plot_qq()` - Q-Q plot for visual goodness-of-fit assessment\n   - `fitter.plot_pp()` - P-P plot for assessing fit in the center of distribution\n   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n\n6. **Goodness-of-Fit Metrics**:\n   - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n   - **A-D statistic** - Lower is better, more sensitive to tails than K-S\n   - **p-value** - Higher is better (>0.05 suggests good fit)\n   - **A-D p-value** - Only available for norm, expon, logistic, gumbel_r, gumbel_l\n   - **SSE** - Sum of squared errors between histogram and fitted PDF\n   - **AIC/BIC** - Information criteria for model comparison"
   },
   {
    "cell_type": "code",

--- a/examples/discrete_demo.ipynb
+++ b/examples/discrete_demo.ipynb
@@ -303,9 +303,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "goalceaw8du",
+   "source": "## 6.1 Parameter Confidence Intervals\n\nCompute bootstrap confidence intervals for discrete distribution parameters.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "sg1cuiitcjj",
+   "source": "# Get parameter names for the best Poisson fit\nprint(f\"Distribution: {best.distribution}\")\nprint(f\"Parameter names: {best.get_param_names()}\")\nprint(f\"Fitted values: {[f'{p:.4f}' for p in best.parameters]}\")\n\n# Compute 95% bootstrap confidence intervals\nprint(\"\\nComputing 95% confidence intervals...\")\nci = best.confidence_intervals(\n    df_poisson,\n    column=\"counts\",\n    alpha=0.05,           # 95% CI\n    n_bootstrap=500,      # Number of bootstrap samples\n    random_seed=42,\n)\n\nprint(\"\\nParameter confidence intervals:\")\nfor param, (lower, upper) in ci.items():\n    print(f\"  {param}: [{lower:.4f}, {upper:.4f}]\")\n\n# Compare to true parameter (λ = 7.5)\nprint(f\"\\nTrue λ = 7.5, fitted λ = {best.parameters[0]:.4f}\")\nprint(f\"95% CI contains true value: {ci['mu'][0] < 7.5 < ci['mu'][1]}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-25",
    "metadata": {},
-   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **DiscreteDistributionFitter** - Main class for fitting discrete distributions\n   - Same API as `DistributionFitter` for continuous data\n   - Uses MLE optimization (discrete dists don't have built-in `fit()`)\n\n2. **Available Distributions**:\n   - poisson, nbinom, geom, binom, hypergeom, betabinom, zipf, and more\n   - 16 discrete distributions by default\n\n3. **Fitting**:\n   - `fitter.fit(df, column)` - Fit all discrete distributions\n   - Returns `FitResults` object (same as continuous)\n\n4. **Model Selection** (recommended metrics):\n   - **AIC** - Best for discrete model selection (lower is better)\n   - **BIC** - Similar to AIC, stronger complexity penalty\n   - K-S statistic works for ranking but p-values are not reliable for discrete data\n   - **A-D statistic is not computed** for discrete distributions (it's designed for continuous CDFs)\n\n5. **Results**:\n   - `results.best(n, metric=\"aic\")` - Get top N distributions by AIC\n   - `results.filter(aic_threshold=...)` - Filter by information criteria\n\n6. **Plotting**:\n   - `fitter.plot()` - Visualize fitted PMF vs empirical histogram\n   - Shows stem plot for discrete probabilities\n\n7. **Use Cases**:\n   - **Poisson**: Event counts with constant rate\n   - **Negative Binomial**: Overdispersed counts (variance > mean)\n   - **Geometric**: Number of trials until first success\n   - **Binomial**: Successes in n trials with probability p"
+   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **DiscreteDistributionFitter** - Main class for fitting discrete distributions\n   - Same API as `DistributionFitter` for continuous data\n   - Uses MLE optimization (discrete dists don't have built-in `fit()`)\n\n2. **Available Distributions**:\n   - poisson, nbinom, geom, binom, hypergeom, betabinom, zipf, and more\n   - 16 discrete distributions by default\n\n3. **Fitting**:\n   - `fitter.fit(df, column)` - Fit all discrete distributions\n   - Returns `FitResults` object (same as continuous)\n\n4. **Model Selection** (recommended metrics):\n   - **AIC** - Best for discrete model selection (lower is better)\n   - **BIC** - Similar to AIC, stronger complexity penalty\n   - K-S statistic works for ranking but p-values are not reliable for discrete data\n   - **A-D statistic is not computed** for discrete distributions (it's designed for continuous CDFs)\n\n5. **Results**:\n   - `results.best(n, metric=\"aic\")` - Get top N distributions by AIC\n   - `results.filter(aic_threshold=...)` - Filter by information criteria\n   - `result.get_param_names()` - Get parameter names for the distribution\n   - `result.confidence_intervals()` - Bootstrap confidence intervals\n\n6. **Plotting**:\n   - `fitter.plot()` - Visualize fitted PMF vs empirical histogram\n   - Shows stem plot for discrete probabilities\n\n7. **Use Cases**:\n   - **Poisson**: Event counts with constant rate\n   - **Negative Binomial**: Overdispersed counts (variance > mean)\n   - **Geometric**: Number of trials until first success\n   - **Binomial**: Successes in n trials with probability p"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Add `DistributionFitResult.get_param_names()` method to retrieve parameter names
- Add `DistributionFitResult.confidence_intervals(df, column, ...)` method for bootstrap CIs
- Support both continuous and discrete distributions
- Memory-safe: automatically samples large DataFrames (default 10k rows max)

## New API

```python
# Get parameter names
best.get_param_names()  # ['a', 'loc', 'scale'] for gamma

# Compute 95% bootstrap confidence intervals
ci = best.confidence_intervals(df, column="value", alpha=0.05, n_bootstrap=1000, random_seed=42)
for param, (lower, upper) in ci.items():
    print(f"{param}: [{lower:.4f}, {upper:.4f}]")
```

## Changes
- `src/spark_bestfit/fitting.py` - `get_continuous_param_names()`, `bootstrap_confidence_intervals()`
- `src/spark_bestfit/discrete_fitting.py` - `get_discrete_param_names()`, `bootstrap_discrete_confidence_intervals()`
- `src/spark_bestfit/results.py` - `get_param_names()`, `confidence_intervals()` methods on `DistributionFitResult`
- Updated docs, examples, and comprehensive tests

Closes #11