### PR TITLE
fix: broadcast cleanup bug and add failure mode tests

### DIFF
--- a/src/spark_bestfit/core.py
+++ b/src/spark_bestfit/core.py
@@ -147,20 +147,20 @@ class DistributionFitter:
         logger.info("Creating data sample for parameter fitting...")
         data_sample = self._create_fitting_sample(df_sample, column, row_count)
         data_sample_bc = self.spark.sparkContext.broadcast(data_sample)
-        logger.info(f"Data sample size: {len(data_sample)}")
-
-        # Get distributions to fit
-        distributions = self._registry.get_distributions(
-            support_at_zero=support_at_zero,
-            additional_exclusions=list(self.excluded_distributions),
-        )
-
-        if max_distributions is not None and max_distributions > 0:
-            distributions = distributions[:max_distributions]
-
-        logger.info(f"Fitting {len(distributions)} distributions...")
 
         try:
+            logger.info(f"Data sample size: {len(data_sample)}")
+
+            # Get distributions to fit
+            distributions = self._registry.get_distributions(
+                support_at_zero=support_at_zero,
+                additional_exclusions=list(self.excluded_distributions),
+            )
+
+            if max_distributions is not None and max_distributions > 0:
+                distributions = distributions[:max_distributions]
+
+            logger.info(f"Fitting {len(distributions)} distributions...")
             # Create DataFrame of distributions
             dist_df = self.spark.createDataFrame([(dist,) for dist in distributions], ["distribution_name"])
 
@@ -704,17 +704,17 @@ class DiscreteDistributionFitter:
         histogram_bc = self.spark.sparkContext.broadcast((x_values, empirical_pmf))
         data_sample_bc = self.spark.sparkContext.broadcast(data_sample)
 
-        # Get distributions to fit
-        distributions = self._registry.get_distributions(
-            additional_exclusions=list(self.excluded_distributions),
-        )
-
-        if max_distributions is not None and max_distributions > 0:
-            distributions = distributions[:max_distributions]
-
-        logger.info(f"Fitting {len(distributions)} discrete distributions...")
-
         try:
+            # Get distributions to fit
+            distributions = self._registry.get_distributions(
+                additional_exclusions=list(self.excluded_distributions),
+            )
+
+            if max_distributions is not None and max_distributions > 0:
+                distributions = distributions[:max_distributions]
+
+            logger.info(f"Fitting {len(distributions)} discrete distributions...")
+
             # Create DataFrame of distributions
             dist_df = self.spark.createDataFrame([(dist,) for dist in distributions], ["distribution_name"])
 


### PR DESCRIPTION
## Summary

- Fix broadcast memory leak where broadcasts were created before the try block, causing them to leak if exceptions occurred during `get_distributions()` or other pre-fitting operations
- Add failure mode tests that verify broadcasts are cleaned up even when exceptions occur during the fitting process

## Changes

- Move try block to immediately after broadcast creation in both `DistributionFitter.fit()` and `DiscreteDistributionFitter.fit()`
- Add 2 new tests to `TestBroadcastCleanup` class that inject exceptions and verify `unpersist()` is still called