### PR TITLE
chore: add Literal type hints for metric parameters

### DIFF
--- a/src/spark_bestfit/__init__.py
+++ b/src/spark_bestfit/__init__.py
@@ -31,7 +31,7 @@ from spark_bestfit.core import (
     DistributionFitter,
 )
 from spark_bestfit.distributions import DiscreteDistributionRegistry, DistributionRegistry
-from spark_bestfit.results import DistributionFitResult, FitResults
+from spark_bestfit.results import DistributionFitResult, FitResults, MetricName
 from spark_bestfit.utils import get_spark_session
 
 __author__ = "Dustin Smith"
@@ -47,6 +47,8 @@ __all__ = [
     # Results
     "FitResults",
     "DistributionFitResult",
+    # Type aliases
+    "MetricName",
     # Distribution management
     "DistributionRegistry",
     "DiscreteDistributionRegistry",

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -1,7 +1,7 @@
 """Results handling for fitted distributions."""
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,9 @@ from pyspark.sql import DataFrame
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame as SparkDataFrame
+
+# Type alias for valid metric names (for IDE autocomplete and type checking)
+MetricName = Literal["sse", "aic", "bic", "ks_statistic", "ad_statistic"]
 
 
 @dataclass
@@ -297,7 +300,7 @@ class FitResults:
         """
         return self._df
 
-    def best(self, n: int = 1, metric: str = "ks_statistic") -> List[DistributionFitResult]:
+    def best(self, n: int = 1, metric: MetricName = "ks_statistic") -> List[DistributionFitResult]:
         """Get top n distributions by specified metric.
 
         Args:


### PR DESCRIPTION
## Summary
- Add `MetricName` type alias (`Literal["sse", "aic", "bic", "ks_statistic", "ad_statistic"]`) for improved IDE autocomplete and static type checking
- Update `FitResults.best()` method signature to use `MetricName` instead of `str`
- Export `MetricName` from `spark_bestfit` package for user type annotations