### PR TITLE
docs: add roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ spark-bestfit is designed for **batch processing** of statistical distribution f
 
 **Known limitations:**
 - No real-time/streaming support (batch processing only)
-- Custom distribution support planned for 1.3.0
+- See [Roadmap](#roadmap) for planned features
 
 ## Installation
 
@@ -336,6 +336,20 @@ fitter = DistributionFitter(spark, excluded_distributions=exclusions)
 # Or exclude nothing (fit all distributions - may be slow)
 fitter = DistributionFitter(spark, excluded_distributions=())
 ```
+
+## Roadmap
+
+spark-bestfit enables downstream use cases (simulations, ML, analytics) by providing distribution fitting primitives.
+
+| Version | Focus | Key Features |
+|---------|-------|--------------|
+| **1.3.0** | Downstream Enablement | Serialization/export, distributed sampling, copulas for correlation, fit quality warnings |
+| **1.4.0** | Bounded Distributions | Truncated distribution fitting for data with natural bounds |
+| **2.0.0** | Custom Distributions | User-defined distribution classes |
+| **2.1.0** | Multivariate | Optional multivariate distribution fitting (MVN, MVt) |
+| **3.0.0** | Advanced | Mixture models, streaming support |
+
+See the [GitHub milestones](https://github.com/dwsmith1983/spark-bestfit/milestones) for detailed issue tracking.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Add a Roadmap section to README documenting planned milestones from v1.3.0 through v3.0.0, with links to GitHub milestones for detailed tracking.

## Related Issues

Related to milestones: 1.3.0, 1.4.0, 2.0.0, 2.1.0, 3.0.0

## Changes Made

- Add Roadmap section with version milestones table
- Update Known limitations to reference roadmap instead of hardcoding "1.3.0"
- Add link to GitHub milestones page

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Testing

- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [ ] Tested manually with example code

## Checklist

- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally