### PR TITLE
fix: remove redundant DataFrame caching warnings

### DIFF
--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -3,7 +3,20 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# spark-bestfit API Demo\n\nThis notebook demonstrates the complete API for the `spark-bestfit` library, including:\n\n1. **Distribution Fitting** - Using DistributionFitter with direct parameters\n2. **Progress Tracking** - Monitor long-running fits with callbacks\n3. **Working with Results** - FitResults and DistributionFitResult objects\n4. **Lazy Metrics** - Skip KS/AD computation for faster model selection (v1.5.0+)\n5. **Confidence Intervals** - Bootstrap confidence intervals for fitted parameters\n6. **Plotting** - Visualization with customizable parameters\n7. **Excluding Distributions** - Customizing which distributions to fit\n8. **Serialization** - Save and load fitted distributions"
+   "source": [
+    "# spark-bestfit API Demo\n",
+    "\n",
+    "This notebook demonstrates the complete API for the `spark-bestfit` library, including:\n",
+    "\n",
+    "1. **Distribution Fitting** - Using DistributionFitter with direct parameters\n",
+    "2. **Progress Tracking** - Monitor long-running fits with callbacks\n",
+    "3. **Working with Results** - FitResults and DistributionFitResult objects\n",
+    "4. **Lazy Metrics** - Skip KS/AD computation for faster model selection (v1.5.0+)\n",
+    "5. **Confidence Intervals** - Bootstrap confidence intervals for fitted parameters\n",
+    "6. **Plotting** - Visualization with customizable parameters\n",
+    "7. **Excluding Distributions** - Customizing which distributions to fit\n",
+    "8. **Serialization** - Save and load fitted distributions"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -19,10 +32,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:21.590866Z",
-     "iopub.status.busy": "2025-12-31T16:56:21.590692Z",
-     "iopub.status.idle": "2025-12-31T16:56:23.768906Z",
-     "shell.execute_reply": "2025-12-31T16:56:23.768435Z"
+     "iopub.execute_input": "2026-01-01T14:36:19.830791Z",
+     "iopub.status.busy": "2026-01-01T14:36:19.830603Z",
+     "iopub.status.idle": "2026-01-01T14:36:22.653099Z",
+     "shell.execute_reply": "2026-01-01T14:36:22.652683Z"
     }
    },
    "outputs": [
@@ -38,8 +51,8 @@
      "output_type": "stream",
      "text": [
       "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
-      "25/12/31 23:56:22 WARN Utils: Your hostname, 2025m5.local, resolves to a loopback address: 127.0.0.1; using 192.168.1.201 instead (on interface en0)\n",
-      "25/12/31 23:56:22 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "26/01/01 21:36:20 WARN Utils: Your hostname, 2025m5.local, resolves to a loopback address: 127.0.0.1; using 192.168.1.201 instead (on interface en0)\n",
+      "26/01/01 21:36:20 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
       "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
@@ -49,7 +62,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "25/12/31 23:56:22 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "26/01/01 21:36:20 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -81,10 +94,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:23.770065Z",
-     "iopub.status.busy": "2025-12-31T16:56:23.769960Z",
-     "iopub.status.idle": "2025-12-31T16:56:24.076935Z",
-     "shell.execute_reply": "2025-12-31T16:56:24.076514Z"
+     "iopub.execute_input": "2026-01-01T14:36:22.654518Z",
+     "iopub.status.busy": "2026-01-01T14:36:22.654376Z",
+     "iopub.status.idle": "2026-01-01T14:36:22.968242Z",
+     "shell.execute_reply": "2026-01-01T14:36:22.967849Z"
     }
    },
    "outputs": [],
@@ -110,10 +123,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:24.078115Z",
-     "iopub.status.busy": "2025-12-31T16:56:24.078029Z",
-     "iopub.status.idle": "2025-12-31T16:56:25.964180Z",
-     "shell.execute_reply": "2025-12-31T16:56:25.963673Z"
+     "iopub.execute_input": "2026-01-01T14:36:22.969519Z",
+     "iopub.status.busy": "2026-01-01T14:36:22.969431Z",
+     "iopub.status.idle": "2026-01-01T14:36:25.100027Z",
+     "shell.execute_reply": "2026-01-01T14:36:25.099307Z"
     }
    },
    "outputs": [
@@ -122,9 +135,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 0:>                                                        (0 + 10) / 10]\r",
-      "\r",
-      "                                                                                \r"
+      "[Stage 0:>                                                        (0 + 10) / 10]\r"
      ]
     },
     {
@@ -134,6 +145,14 @@
       "Normal data: 50,000 rows, mean=50.00, std=10.00\n",
       "Exponential data: 50,000 rows, mean=4.97\n",
       "Gamma data: 50,000 rows, mean=4.01\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                                \r"
      ]
     }
    ],
@@ -182,10 +201,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:25.965870Z",
-     "iopub.status.busy": "2025-12-31T16:56:25.965773Z",
-     "iopub.status.idle": "2025-12-31T16:56:25.967713Z",
-     "shell.execute_reply": "2025-12-31T16:56:25.967170Z"
+     "iopub.execute_input": "2026-01-01T14:36:25.102379Z",
+     "iopub.status.busy": "2026-01-01T14:36:25.102218Z",
+     "iopub.status.idle": "2026-01-01T14:36:25.104935Z",
+     "shell.execute_reply": "2026-01-01T14:36:25.104283Z"
     }
    },
    "outputs": [
@@ -226,10 +245,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:25.968706Z",
-     "iopub.status.busy": "2025-12-31T16:56:25.968649Z",
-     "iopub.status.idle": "2025-12-31T16:56:25.970448Z",
-     "shell.execute_reply": "2025-12-31T16:56:25.970117Z"
+     "iopub.execute_input": "2026-01-01T14:36:25.105919Z",
+     "iopub.status.busy": "2026-01-01T14:36:25.105855Z",
+     "iopub.status.idle": "2026-01-01T14:36:25.107523Z",
+     "shell.execute_reply": "2026-01-01T14:36:25.107144Z"
     }
    },
    "outputs": [
@@ -272,10 +291,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:25.971437Z",
-     "iopub.status.busy": "2025-12-31T16:56:25.971386Z",
-     "iopub.status.idle": "2025-12-31T16:56:30.071787Z",
-     "shell.execute_reply": "2025-12-31T16:56:30.071395Z"
+     "iopub.execute_input": "2026-01-01T14:36:25.108527Z",
+     "iopub.status.busy": "2026-01-01T14:36:25.108471Z",
+     "iopub.status.idle": "2026-01-01T14:36:29.414109Z",
+     "shell.execute_reply": "2026-01-01T14:36:29.413508Z"
     }
    },
    "outputs": [
@@ -299,6 +318,8 @@
      "output_type": "stream",
      "text": [
       "\r",
+      "[Stage 24:======================>                                  (4 + 6) / 10]\r",
+      "\r",
       "[Stage 24:===================================================>     (9 + 1) / 10]\r"
      ]
     },
@@ -319,14 +340,6 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Fitted 20 distributions\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
@@ -334,6 +347,14 @@
       "[Stage 32:=====================================================>  (19 + 1) / 20]\r",
       "\r",
       "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Fitted 20 distributions\n"
      ]
     }
    ],
@@ -360,10 +381,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:30.072830Z",
-     "iopub.status.busy": "2025-12-31T16:56:30.072770Z",
-     "iopub.status.idle": "2025-12-31T16:56:32.342618Z",
-     "shell.execute_reply": "2025-12-31T16:56:32.342278Z"
+     "iopub.execute_input": "2026-01-01T14:36:29.416430Z",
+     "iopub.status.busy": "2026-01-01T14:36:29.416291Z",
+     "iopub.status.idle": "2026-01-01T14:36:31.733545Z",
+     "shell.execute_reply": "2026-01-01T14:36:31.732873Z"
     }
    },
    "outputs": [
@@ -372,32 +393,6 @@
      "output_type": "stream",
      "text": [
       "Fitting non-negative distributions to exponential data...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "[Stage 58:===================================================>     (9 + 1) / 10]\r",
-      "\r",
-      "                                                                                \r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "[Stage 64:===================================================>     (9 + 1) / 10]\r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "[Stage 66:====================================================>   (14 + 1) / 15]\r"
      ]
     },
     {
@@ -411,6 +406,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "[Stage 66:====================================================>   (14 + 1) / 15]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -457,10 +454,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:32.343667Z",
-     "iopub.status.busy": "2025-12-31T16:56:32.343596Z",
-     "iopub.status.idle": "2025-12-31T16:56:34.914390Z",
-     "shell.execute_reply": "2025-12-31T16:56:34.914033Z"
+     "iopub.execute_input": "2026-01-01T14:36:31.734640Z",
+     "iopub.status.busy": "2026-01-01T14:36:31.734559Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.337098Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.336550Z"
     }
    },
    "outputs": [
@@ -470,7 +467,7 @@
      "text": [
       "Fitting with console_progress()...\n",
       "\r",
-      "Fitting: 22/53 tasks (41.5%)"
+      "Fitting: 21/42 tasks (50.0%)"
      ]
     },
     {
@@ -486,7 +483,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 36/85 tasks (42.4%)"
+      "Fitting: 35/85 tasks (41.2%)"
      ]
     },
     {
@@ -502,7 +499,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 42/85 tasks (49.4%)"
+      "Fitting: 41/85 tasks (48.2%)"
      ]
     },
     {
@@ -510,7 +507,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 43/85 tasks (50.6%)"
+      "Fitting: 44/85 tasks (51.8%)"
      ]
     },
     {
@@ -528,14 +525,6 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 65/156 tasks (41.7%)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
       "Fitting: 67/156 tasks (42.9%)"
      ]
     },
@@ -544,23 +533,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 71/156 tasks (45.5%)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
       "Fitting: 73/156 tasks (46.8%)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Fitting: 75/156 tasks (48.1%)"
      ]
     },
     {
@@ -576,7 +549,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 81/186 tasks (43.5%)"
+      "Fitting: 75/186 tasks (40.3%)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting: 82/186 tasks (44.1%)"
      ]
     },
     {
@@ -592,7 +573,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Fitting: 93/186 tasks (50.0%)"
+      "Fitting: 94/186 tasks (50.5%)"
      ]
     },
     {
@@ -601,6 +582,14 @@
      "text": [
       "\r",
       "[Stage 100:====================================================>  (19 + 1) / 20]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting: 95/216 tasks (44.0%)"
      ]
     },
     {
@@ -650,10 +639,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:34.915421Z",
-     "iopub.status.busy": "2025-12-31T16:56:34.915358Z",
-     "iopub.status.idle": "2025-12-31T16:56:34.917308Z",
-     "shell.execute_reply": "2025-12-31T16:56:34.917007Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.338112Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.338049Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.340120Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.339777Z"
     }
    },
    "outputs": [
@@ -694,10 +683,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:34.918241Z",
-     "iopub.status.busy": "2025-12-31T16:56:34.918178Z",
-     "iopub.status.idle": "2025-12-31T16:56:34.964643Z",
-     "shell.execute_reply": "2025-12-31T16:56:34.964166Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.341002Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.340946Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.419767Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.419089Z"
     }
    },
    "outputs": [
@@ -736,10 +725,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:34.966458Z",
-     "iopub.status.busy": "2025-12-31T16:56:34.966317Z",
-     "iopub.status.idle": "2025-12-31T16:56:35.088429Z",
-     "shell.execute_reply": "2025-12-31T16:56:35.088104Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.422381Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.422211Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.584681Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.584369Z"
     }
    },
    "outputs": [
@@ -754,27 +743,33 @@
       "  4. erlang               KS=0.007768 p=0.5791\n",
       "  5. burr12               KS=0.011640 p=0.1318\n",
       "\n",
-      "Top 5 by A-D statistic:\n",
-      "  1. beta                 AD=0.162459 p=N/A\n",
-      "  2. exponnorm            AD=0.273818 p=N/A\n",
-      "  3. crystalball          AD=0.273819 p=N/A\n",
-      "  4. erlang               AD=0.500780 p=N/A\n",
-      "  5. burr12               AD=1.659597 p=N/A\n",
-      "\n",
-      "Top 5 by SSE:\n",
-      "  1. exponnorm            SSE=0.000012\n",
-      "  2. crystalball          SSE=0.000012\n",
-      "  3. beta                 SSE=0.000013\n",
-      "  4. erlang               SSE=0.000014\n",
-      "  5. burr12               SSE=0.000036\n",
-      "\n",
-      "Top 5 by AIC:\n"
+      "Top 5 by A-D statistic:\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  1. beta                 AD=0.162459 p=N/A\n",
+      "  2. exponnorm            AD=0.273818 p=N/A\n",
+      "  3. crystalball          AD=0.273819 p=N/A\n",
+      "  4. erlang               AD=0.500780 p=N/A\n",
+      "  5. burr12               AD=1.659597 p=N/A\n",
+      "\n",
+      "Top 5 by SSE:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. exponnorm            SSE=0.000012\n",
+      "  2. crystalball          SSE=0.000012\n",
+      "  3. beta                 SSE=0.000013\n",
+      "  4. erlang               SSE=0.000014\n",
+      "  5. burr12               SSE=0.000036\n",
+      "\n",
+      "Top 5 by AIC:\n",
       "  1. exponnorm            AIC=74641.05\n",
       "  2. beta                 AIC=74641.52\n",
       "  3. crystalball          AIC=74643.05\n",
@@ -815,10 +810,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:35.089449Z",
-     "iopub.status.busy": "2025-12-31T16:56:35.089389Z",
-     "iopub.status.idle": "2025-12-31T16:56:35.319407Z",
-     "shell.execute_reply": "2025-12-31T16:56:35.318951Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.585779Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.585708Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.858089Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.857684Z"
     }
    },
    "outputs": [
@@ -842,7 +837,13 @@
       "  dweibull             KS=0.015396 p=0.0172\n",
       "  burr                 KS=0.022808 p=0.0001\n",
       "  dgamma               KS=0.023571 p=0.0000\n",
-      "  chi2                 KS=0.025661 p=0.0000\n",
+      "  chi2                 KS=0.025661 p=0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Distributions with p-value > 0.05: 5\n"
      ]
@@ -885,10 +886,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:35.320875Z",
-     "iopub.status.busy": "2025-12-31T16:56:35.320731Z",
-     "iopub.status.idle": "2025-12-31T16:56:35.348957Z",
-     "shell.execute_reply": "2025-12-31T16:56:35.348458Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.859747Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.859592Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.888481Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.888174Z"
     }
    },
    "outputs": [
@@ -1174,10 +1175,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:35.350080Z",
-     "iopub.status.busy": "2025-12-31T16:56:35.350022Z",
-     "iopub.status.idle": "2025-12-31T16:56:35.379851Z",
-     "shell.execute_reply": "2025-12-31T16:56:35.379479Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.889794Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.889734Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.932294Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.932004Z"
     }
    },
    "outputs": [
@@ -1207,10 +1208,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:35.380841Z",
-     "iopub.status.busy": "2025-12-31T16:56:35.380771Z",
-     "iopub.status.idle": "2025-12-31T16:56:35.383145Z",
-     "shell.execute_reply": "2025-12-31T16:56:35.382836Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.933456Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.933387Z",
+     "iopub.status.idle": "2026-01-01T14:36:34.935736Z",
+     "shell.execute_reply": "2026-01-01T14:36:34.935407Z"
     }
    },
    "outputs": [
@@ -1254,10 +1255,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:35.384151Z",
-     "iopub.status.busy": "2025-12-31T16:56:35.384091Z",
-     "iopub.status.idle": "2025-12-31T16:56:55.046434Z",
-     "shell.execute_reply": "2025-12-31T16:56:55.045970Z"
+     "iopub.execute_input": "2026-01-01T14:36:34.936664Z",
+     "iopub.status.busy": "2026-01-01T14:36:34.936610Z",
+     "iopub.status.idle": "2026-01-01T14:36:54.522511Z",
+     "shell.execute_reply": "2026-01-01T14:36:54.522126Z"
     }
    },
    "outputs": [
@@ -1309,36 +1310,184 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## 3.6 Lazy Metrics for Fast Model Selection (v1.5.0+)\n\nWhen fitting ~100 distributions, computing KS and AD statistics for all of them can be slow. With **lazy metrics**, these expensive computations are skipped during fitting and only computed on-demand when you actually need them.\n\n**Key benefits:**\n- Fast initial fitting (skip KS/AD computation)\n- On-demand computation only for distributions you access\n- Ideal for model selection workflows using AIC/BIC",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 3.6 Lazy Metrics for Fast Model Selection (v1.5.0+)\n",
+    "\n",
+    "When fitting ~100 distributions, computing KS and AD statistics for all of them can be slow. With **lazy metrics**, these expensive computations are skipped during fitting and only computed on-demand when you actually need them.\n",
+    "\n",
+    "**Key benefits:**\n",
+    "- Fast initial fitting (skip KS/AD computation)\n",
+    "- On-demand computation only for distributions you access\n",
+    "- Ideal for model selection workflows using AIC/BIC"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Fit with lazy metrics - KS/AD statistics are NOT computed during fitting\nprint(\"Fitting with lazy_metrics=True (fast)...\")\nfitter_lazy = DistributionFitter(spark)\nresults_lazy = fitter_lazy.fit(\n    df_normal,\n    column=\"value\",\n    max_distributions=20,\n    lazy_metrics=True,  # Skip KS/AD computation!\n)\n\nprint(f\"Fitted {results_lazy.count()} distributions\")\nprint(f\"Is lazy: {results_lazy.is_lazy}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:36:54.523666Z",
+     "iopub.status.busy": "2026-01-01T14:36:54.523598Z",
+     "iopub.status.idle": "2026-01-01T14:36:56.609466Z",
+     "shell.execute_reply": "2026-01-01T14:36:56.609078Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting with lazy_metrics=True (fast)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitted 20 distributions\n",
+      "Is lazy: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fit with lazy metrics - KS/AD statistics are NOT computed during fitting\n",
+    "print(\"Fitting with lazy_metrics=True (fast)...\")\n",
+    "fitter_lazy = DistributionFitter(spark)\n",
+    "results_lazy = fitter_lazy.fit(\n",
+    "    df_normal,\n",
+    "    column=\"value\",\n",
+    "    max_distributions=20,\n",
+    "    lazy_metrics=True,  # Skip KS/AD computation!\n",
+    ")\n",
+    "\n",
+    "print(f\"Fitted {results_lazy.count()} distributions\")\n",
+    "print(f\"Is lazy: {results_lazy.is_lazy}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Get best by AIC - fast! No KS/AD computation needed\nbest_aic = results_lazy.best(n=1, metric=\"aic\")[0]\n\nprint(f\"Best by AIC: {best_aic.distribution}\")\nprint(f\"  AIC: {best_aic.aic:.2f}\")\nprint(f\"  BIC: {best_aic.bic:.2f}\")\nprint(f\"  KS statistic: {best_aic.ks_statistic}\")  # None - not computed yet!\nprint(f\"  AD statistic: {best_aic.ad_statistic}\")  # None - not computed yet!",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:36:56.610347Z",
+     "iopub.status.busy": "2026-01-01T14:36:56.610286Z",
+     "iopub.status.idle": "2026-01-01T14:36:56.636944Z",
+     "shell.execute_reply": "2026-01-01T14:36:56.636641Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best by AIC: exponnorm\n",
+      "  AIC: 74641.05\n",
+      "  BIC: 74662.68\n",
+      "  KS statistic: None\n",
+      "  AD statistic: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get best by AIC - fast! No KS/AD computation needed\n",
+    "best_aic = results_lazy.best(n=1, metric=\"aic\")[0]\n",
+    "\n",
+    "print(f\"Best by AIC: {best_aic.distribution}\")\n",
+    "print(f\"  AIC: {best_aic.aic:.2f}\")\n",
+    "print(f\"  BIC: {best_aic.bic:.2f}\")\n",
+    "print(f\"  KS statistic: {best_aic.ks_statistic}\")  # None - not computed yet!\n",
+    "print(f\"  AD statistic: {best_aic.ad_statistic}\")  # None - not computed yet!"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Get best by KS statistic - triggers ON-DEMAND computation!\n# Only computes KS/AD for top candidates, not all distributions\nbest_ks = results_lazy.best(n=1, metric=\"ks_statistic\")[0]\n\nprint(f\"Best by KS: {best_ks.distribution}\")\nprint(f\"  KS statistic: {best_ks.ks_statistic:.6f}\")  # Computed on-demand!\nprint(f\"  p-value: {best_ks.pvalue:.4f}\")\nprint(f\"  AD statistic: {best_ks.ad_statistic:.6f}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 19,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:36:56.638095Z",
+     "iopub.status.busy": "2026-01-01T14:36:56.638038Z",
+     "iopub.status.idle": "2026-01-01T14:36:56.889241Z",
+     "shell.execute_reply": "2026-01-01T14:36:56.888831Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best by KS: beta\n",
+      "  KS statistic: 0.005229\n",
+      "  p-value: 0.9459\n",
+      "  AD statistic: 0.162459\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/dustin/.venvs/base/lib/python3.13/site-packages/scipy/stats/_distn_infrastructure.py:527: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(5907.56054688).\n",
+      "  return self.dist.cdf(x, *self.args, **self.kwds)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get best by KS statistic - triggers ON-DEMAND computation!\n",
+    "# Only computes KS/AD for top candidates, not all distributions\n",
+    "best_ks = results_lazy.best(n=1, metric=\"ks_statistic\")[0]\n",
+    "\n",
+    "print(f\"Best by KS: {best_ks.distribution}\")\n",
+    "print(f\"  KS statistic: {best_ks.ks_statistic:.6f}\")  # Computed on-demand!\n",
+    "print(f\"  p-value: {best_ks.pvalue:.4f}\")\n",
+    "print(f\"  AD statistic: {best_ks.ad_statistic:.6f}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# If you need all metrics computed (e.g., before unpersisting source data),\n# use materialize() to force computation of all KS/AD statistics\nmaterialized = results_lazy.materialize()\n\nprint(f\"Is lazy after materialize: {materialized.is_lazy}\")  # False\n\n# Now all distributions have KS/AD computed\ntop_3 = materialized.best(n=3, metric=\"ks_statistic\")\nprint(\"\\nTop 3 distributions (all metrics available):\")\nfor i, r in enumerate(top_3, 1):\n    print(f\"  {i}. {r.distribution:15} KS={r.ks_statistic:.6f} p={r.pvalue:.4f}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 20,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:36:56.890286Z",
+     "iopub.status.busy": "2026-01-01T14:36:56.890226Z",
+     "iopub.status.idle": "2026-01-01T14:36:57.153895Z",
+     "shell.execute_reply": "2026-01-01T14:36:57.153587Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Is lazy after materialize: False\n",
+      "\n",
+      "Top 3 distributions (all metrics available):\n",
+      "  1. beta            KS=0.005229 p=0.9459\n",
+      "  2. exponnorm       KS=0.006004 p=0.8612\n",
+      "  3. crystalball     KS=0.006005 p=0.8612\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/dustin/.venvs/base/lib/python3.13/site-packages/scipy/stats/_distn_infrastructure.py:527: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(5907.56054688).\n",
+      "  return self.dist.cdf(x, *self.args, **self.kwds)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# If you need all metrics computed (e.g., before unpersisting source data),\n",
+    "# use materialize() to force computation of all KS/AD statistics\n",
+    "materialized = results_lazy.materialize()\n",
+    "\n",
+    "print(f\"Is lazy after materialize: {materialized.is_lazy}\")  # False\n",
+    "\n",
+    "# Now all distributions have KS/AD computed\n",
+    "top_3 = materialized.best(n=3, metric=\"ks_statistic\")\n",
+    "print(\"\\nTop 3 distributions (all metrics available):\")\n",
+    "for i, r in enumerate(top_3, 1):\n",
+    "    print(f\"  {i}. {r.distribution:15} KS={r.ks_statistic:.6f} p={r.pvalue:.4f}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1353,13 +1502,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:55.047396Z",
-     "iopub.status.busy": "2025-12-31T16:56:55.047345Z",
-     "iopub.status.idle": "2025-12-31T16:56:55.208151Z",
-     "shell.execute_reply": "2025-12-31T16:56:55.207759Z"
+     "iopub.execute_input": "2026-01-01T14:36:57.154900Z",
+     "iopub.status.busy": "2026-01-01T14:36:57.154842Z",
+     "iopub.status.idle": "2026-01-01T14:36:57.306547Z",
+     "shell.execute_reply": "2026-01-01T14:36:57.306168Z"
     }
    },
    "outputs": [],
@@ -1377,13 +1526,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:55.209438Z",
-     "iopub.status.busy": "2025-12-31T16:56:55.209316Z",
-     "iopub.status.idle": "2025-12-31T16:56:55.466928Z",
-     "shell.execute_reply": "2025-12-31T16:56:55.466525Z"
+     "iopub.execute_input": "2026-01-01T14:36:57.307896Z",
+     "iopub.status.busy": "2026-01-01T14:36:57.307810Z",
+     "iopub.status.idle": "2026-01-01T14:36:57.554369Z",
+     "shell.execute_reply": "2026-01-01T14:36:57.554035Z"
     }
    },
    "outputs": [
@@ -1420,13 +1569,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:55.467855Z",
-     "iopub.status.busy": "2025-12-31T16:56:55.467792Z",
-     "iopub.status.idle": "2025-12-31T16:56:55.695881Z",
-     "shell.execute_reply": "2025-12-31T16:56:55.695488Z"
+     "iopub.execute_input": "2026-01-01T14:36:57.555458Z",
+     "iopub.status.busy": "2026-01-01T14:36:57.555380Z",
+     "iopub.status.idle": "2026-01-01T14:36:57.769289Z",
+     "shell.execute_reply": "2026-01-01T14:36:57.768942Z"
     }
    },
    "outputs": [
@@ -1471,13 +1620,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:55.696876Z",
-     "iopub.status.busy": "2025-12-31T16:56:55.696812Z",
-     "iopub.status.idle": "2025-12-31T16:56:55.951025Z",
-     "shell.execute_reply": "2025-12-31T16:56:55.950685Z"
+     "iopub.execute_input": "2026-01-01T14:36:57.770288Z",
+     "iopub.status.busy": "2026-01-01T14:36:57.770228Z",
+     "iopub.status.idle": "2026-01-01T14:36:58.028763Z",
+     "shell.execute_reply": "2026-01-01T14:36:58.028348Z"
     }
    },
    "outputs": [
@@ -1494,9 +1643,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/dustin/Documents/code/spark-bestfit/src/spark_bestfit/fitting.py:884: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(1.00182939).\n",
+      "/Users/dustin/Documents/code/spark-bestfit/src/spark_bestfit/fitting.py:952: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(1.00182939).\n",
       "  start = dist.ppf(percentile, *shape, loc=loc, scale=scale)\n",
-      "/Users/dustin/Documents/code/spark-bestfit/src/spark_bestfit/fitting.py:885: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(1.00182939).\n",
+      "/Users/dustin/Documents/code/spark-bestfit/src/spark_bestfit/fitting.py:953: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(1.00182939).\n",
       "  end = dist.ppf(1 - percentile, *shape, loc=loc, scale=scale)\n",
       "/Users/dustin/Documents/code/spark-bestfit/src/spark_bestfit/plotting.py:78: RuntimeWarning: The shape parameter of the erlang distribution has been given a non-integer value array(1.00182939).\n",
       "  y_pdf = dist.pdf(x_pdf, *shape, loc=loc, scale=scale)\n"
@@ -1547,13 +1696,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:55.952093Z",
-     "iopub.status.busy": "2025-12-31T16:56:55.952021Z",
-     "iopub.status.idle": "2025-12-31T16:56:56.170910Z",
-     "shell.execute_reply": "2025-12-31T16:56:56.170564Z"
+     "iopub.execute_input": "2026-01-01T14:36:58.030092Z",
+     "iopub.status.busy": "2026-01-01T14:36:58.030013Z",
+     "iopub.status.idle": "2026-01-01T14:36:58.259381Z",
+     "shell.execute_reply": "2026-01-01T14:36:58.259004Z"
     }
    },
    "outputs": [
@@ -1621,13 +1770,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:56.171998Z",
-     "iopub.status.busy": "2025-12-31T16:56:56.171931Z",
-     "iopub.status.idle": "2025-12-31T16:56:56.394985Z",
-     "shell.execute_reply": "2025-12-31T16:56:56.394554Z"
+     "iopub.execute_input": "2026-01-01T14:36:58.260716Z",
+     "iopub.status.busy": "2026-01-01T14:36:58.260626Z",
+     "iopub.status.idle": "2026-01-01T14:36:58.469950Z",
+     "shell.execute_reply": "2026-01-01T14:36:58.469628Z"
     }
    },
    "outputs": [
@@ -1704,13 +1853,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:56.396182Z",
-     "iopub.status.busy": "2025-12-31T16:56:56.396107Z",
-     "iopub.status.idle": "2025-12-31T16:56:56.565299Z",
-     "shell.execute_reply": "2025-12-31T16:56:56.564911Z"
+     "iopub.execute_input": "2026-01-01T14:36:58.471078Z",
+     "iopub.status.busy": "2026-01-01T14:36:58.471018Z",
+     "iopub.status.idle": "2026-01-01T14:36:58.640827Z",
+     "shell.execute_reply": "2026-01-01T14:36:58.640422Z"
     }
    },
    "outputs": [
@@ -1750,13 +1899,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:56.566276Z",
-     "iopub.status.busy": "2025-12-31T16:56:56.566211Z",
-     "iopub.status.idle": "2025-12-31T16:56:59.516801Z",
-     "shell.execute_reply": "2025-12-31T16:56:59.516368Z"
+     "iopub.execute_input": "2026-01-01T14:36:58.642514Z",
+     "iopub.status.busy": "2026-01-01T14:36:58.642385Z",
+     "iopub.status.idle": "2026-01-01T14:37:01.576368Z",
+     "shell.execute_reply": "2026-01-01T14:37:01.575987Z"
     }
    },
    "outputs": [
@@ -1772,9 +1921,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 284:=====================================================> (44 + 1) / 45]\r",
-      "\r",
-      "                                                                                \r"
+      "[Stage 386:==================================================>     (9 + 1) / 10]\r"
      ]
     },
     {
@@ -1784,6 +1931,16 @@
       "\n",
       "Total results: 45\n",
       "Columns fitted: ['normal_col', 'exp_col', 'gamma_col']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 391:=====================================================> (44 + 1) / 45]\r",
+      "\r",
+      "                                                                                \r"
      ]
     }
    ],
@@ -1812,13 +1969,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:59.517977Z",
-     "iopub.status.busy": "2025-12-31T16:56:59.517905Z",
-     "iopub.status.idle": "2025-12-31T16:56:59.755157Z",
-     "shell.execute_reply": "2025-12-31T16:56:59.754742Z"
+     "iopub.execute_input": "2026-01-01T14:37:01.577455Z",
+     "iopub.status.busy": "2026-01-01T14:37:01.577390Z",
+     "iopub.status.idle": "2026-01-01T14:37:01.894325Z",
+     "shell.execute_reply": "2026-01-01T14:37:01.893856Z"
     }
    },
    "outputs": [
@@ -1871,13 +2028,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:59.756110Z",
-     "iopub.status.busy": "2025-12-31T16:56:59.756045Z",
-     "iopub.status.idle": "2025-12-31T16:56:59.840996Z",
-     "shell.execute_reply": "2025-12-31T16:56:59.840689Z"
+     "iopub.execute_input": "2026-01-01T14:37:01.895506Z",
+     "iopub.status.busy": "2026-01-01T14:37:01.895446Z",
+     "iopub.status.idle": "2026-01-01T14:37:02.039530Z",
+     "shell.execute_reply": "2026-01-01T14:37:02.038874Z"
     }
    },
    "outputs": [
@@ -1893,13 +2050,6 @@
       "  3. burr12          KS=0.006666\n",
       "  4. betaprime       KS=0.007770\n",
       "  5. burr            KS=0.017501\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "25/12/31 23:56:59 WARN CacheManager: Asked to cache already cached data.\n"
      ]
     }
    ],
@@ -1922,13 +2072,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:56:59.842050Z",
-     "iopub.status.busy": "2025-12-31T16:56:59.841995Z",
-     "iopub.status.idle": "2025-12-31T16:57:00.415258Z",
-     "shell.execute_reply": "2025-12-31T16:57:00.414872Z"
+     "iopub.execute_input": "2026-01-01T14:37:02.040929Z",
+     "iopub.status.busy": "2026-01-01T14:37:02.040832Z",
+     "iopub.status.idle": "2026-01-01T14:37:02.630269Z",
+     "shell.execute_reply": "2026-01-01T14:37:02.629839Z"
     }
    },
    "outputs": [
@@ -1992,13 +2142,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:00.416355Z",
-     "iopub.status.busy": "2025-12-31T16:57:00.416291Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.713978Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.713634Z"
+     "iopub.execute_input": "2026-01-01T14:37:02.631499Z",
+     "iopub.status.busy": "2026-01-01T14:37:02.631424Z",
+     "iopub.status.idle": "2026-01-01T14:37:04.987987Z",
+     "shell.execute_reply": "2026-01-01T14:37:04.987376Z"
     }
    },
    "outputs": [
@@ -2014,7 +2164,25 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 423:====================================================>  (19 + 1) / 20]\r",
+      "[Stage 558:==================================================>     (9 + 1) / 10]\r",
+      "\r",
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 564:==================================================>     (9 + 1) / 10]\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 566:====================================================>  (19 + 1) / 20]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -2137,7 +2305,7 @@
        "24    exponweib      0.006066  0.852823  0.000312  45381.195312  45410.039062"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2210,13 +2378,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.715108Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.715038Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.717972Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.717514Z"
+     "iopub.execute_input": "2026-01-01T14:37:04.989135Z",
+     "iopub.status.busy": "2026-01-01T14:37:04.989064Z",
+     "iopub.status.idle": "2026-01-01T14:37:04.991805Z",
+     "shell.execute_reply": "2026-01-01T14:37:04.991441Z"
     }
    },
    "outputs": [
@@ -2227,10 +2395,10 @@
       "Saving distribution: beta\n",
       "Parameters: [1.9708176851272583, 57.34297180175781, -0.01165021862834692, 120.50712585449219]\n",
       "\n",
-      "Saved to JSON: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpos9ikrc1/best_model.json\n",
+      "Saved to JSON: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpua1h_w3o/best_model.json\n",
       "File size: 756 bytes\n",
       "\n",
-      "Saved to pickle: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpos9ikrc1/best_model.pkl\n",
+      "Saved to pickle: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpua1h_w3o/best_model.pkl\n",
       "File size: 424 bytes\n"
      ]
     }
@@ -2262,13 +2430,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.718933Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.718863Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.721724Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.721349Z"
+     "iopub.execute_input": "2026-01-01T14:37:04.992821Z",
+     "iopub.status.busy": "2026-01-01T14:37:04.992744Z",
+     "iopub.status.idle": "2026-01-01T14:37:04.995405Z",
+     "shell.execute_reply": "2026-01-01T14:37:04.995133Z"
     }
    },
    "outputs": [
@@ -2317,13 +2485,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.722805Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.722733Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.724542Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.724195Z"
+     "iopub.execute_input": "2026-01-01T14:37:04.996432Z",
+     "iopub.status.busy": "2026-01-01T14:37:04.996359Z",
+     "iopub.status.idle": "2026-01-01T14:37:04.998005Z",
+     "shell.execute_reply": "2026-01-01T14:37:04.997735Z"
     }
    },
    "outputs": [
@@ -2365,13 +2533,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.725382Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.725324Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.727058Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.726729Z"
+     "iopub.execute_input": "2026-01-01T14:37:04.998932Z",
+     "iopub.status.busy": "2026-01-01T14:37:04.998880Z",
+     "iopub.status.idle": "2026-01-01T14:37:05.000548Z",
+     "shell.execute_reply": "2026-01-01T14:37:05.000287Z"
     }
    },
    "outputs": [
@@ -2382,8 +2550,8 @@
       "JSON file content:\n",
       "{\n",
       "  \"schema_version\": \"1.1\",\n",
-      "  \"spark_bestfit_version\": \"1.3.2\",\n",
-      "  \"created_at\": \"2025-12-31T16:57:02.716082+00:00\",\n",
+      "  \"spark_bestfit_version\": \"1.5.0\",\n",
+      "  \"created_at\": \"2026-01-01T14:37:04.990125+00:00\",\n",
       "  \"distribution\": \"beta\",\n",
       "  \"parameters\": [\n",
       "    1.9708176851272583,\n",
@@ -2425,13 +2593,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.727859Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.727806Z",
-     "iopub.status.idle": "2025-12-31T16:57:02.729500Z",
-     "shell.execute_reply": "2025-12-31T16:57:02.729197Z"
+     "iopub.execute_input": "2026-01-01T14:37:05.001398Z",
+     "iopub.status.busy": "2026-01-01T14:37:05.001347Z",
+     "iopub.status.idle": "2026-01-01T14:37:05.002971Z",
+     "shell.execute_reply": "2026-01-01T14:37:05.002721Z"
     }
    },
    "outputs": [
@@ -2439,7 +2607,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cleaned up temporary directory: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpos9ikrc1\n"
+      "Cleaned up temporary directory: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpua1h_w3o\n"
      ]
     }
    ],
@@ -2453,17 +2621,82 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Excluded Distributions**:\n   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n\n2. **SparkSession Management**:\n   - You create and configure your own SparkSession\n   - Pass it to `DistributionFitter(spark)` or use active session\n\n3. **Fitting**:\n   - `DistributionFitter.fit()` - Fit distributions to data\n   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n   - `max_distributions` parameter to limit fitting scope\n   - `progress_callback` parameter to monitor long-running fits\n\n4. **Progress Tracking**:\n   - Pass `progress_callback=fn` to `fit()` to receive progress updates\n   - Callback receives `(completed_tasks, total_tasks, percent_complete)`\n   - Works with both `DistributionFitter` and `DiscreteDistributionFitter`\n\n5. **Results**:\n   - `results.best(n, metric)` - Get top N by K-S statistic (default), A-D statistic, SSE, AIC, or BIC\n   - `results.filter(ks_threshold, pvalue_threshold, ad_threshold)` - Filter by goodness-of-fit\n   - `results.df.toPandas()` - Convert to pandas DataFrame\n   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n   - `DistributionFitResult.get_param_names()` - Get parameter names\n   - `DistributionFitResult.confidence_intervals()` - Bootstrap confidence intervals\n\n6. **Lazy Metrics (v1.5.0+)**:\n   - `lazy_metrics=True` - Skip KS/AD computation during fitting for faster iteration\n   - `results.is_lazy` - Check if results have lazy metrics\n   - `results.best(metric=\"ks_statistic\")` - Triggers on-demand computation for top candidates only\n   - `results.materialize()` - Force computation of all KS/AD statistics\n\n7. **Multi-Column Fitting**:\n   - `fitter.fit(df, columns=[...])` - Fit multiple columns in one call\n   - `results.column_names` - List all fitted columns\n   - `results.for_column(name)` - Filter results to one column\n   - `results.best_per_column(n, metric)` - Get top N per column\n\n8. **Plotting**:\n   - `fitter.plot()` - Visualize fitted distribution with data histogram\n   - `fitter.plot_qq()` - Q-Q plot for visual goodness-of-fit assessment\n   - `fitter.plot_pp()` - P-P plot for assessing fit in the center of distribution\n   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n\n9. **Serialization**:\n   - `result.save(path)` - Save to JSON (default) or pickle format\n   - `DistributionFitResult.load(path)` - Load a saved result\n   - `result.data_summary` - Access fitting statistics for provenance\n   - JSON format includes version metadata for compatibility\n\n10. **Goodness-of-Fit Metrics**:\n    - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n    - **A-D statistic** - Lower is better, more sensitive to tails than K-S\n    - **p-value** - Higher is better (>0.05 suggests good fit)\n    - **A-D p-value** - Only available for norm, expon, logistic, gumbel_r, gumbel_l\n    - **SSE** - Sum of squared errors between histogram and fitted PDF\n    - **AIC/BIC** - Information criteria for model comparison"
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "\n",
+    "1. **Excluded Distributions**:\n",
+    "   - `DEFAULT_EXCLUDED_DISTRIBUTIONS` - Slow distributions excluded by default\n",
+    "   - Pass custom `excluded_distributions` to `DistributionFitter()` to include/exclude\n",
+    "\n",
+    "2. **SparkSession Management**:\n",
+    "   - You create and configure your own SparkSession\n",
+    "   - Pass it to `DistributionFitter(spark)` or use active session\n",
+    "\n",
+    "3. **Fitting**:\n",
+    "   - `DistributionFitter.fit()` - Fit distributions to data\n",
+    "   - Parameters: `bins`, `use_rice_rule`, `support_at_zero`, `enable_sampling`, etc.\n",
+    "   - `max_distributions` parameter to limit fitting scope\n",
+    "   - `progress_callback` parameter to monitor long-running fits\n",
+    "\n",
+    "4. **Progress Tracking**:\n",
+    "   - Pass `progress_callback=fn` to `fit()` to receive progress updates\n",
+    "   - Callback receives `(completed_tasks, total_tasks, percent_complete)`\n",
+    "   - Works with both `DistributionFitter` and `DiscreteDistributionFitter`\n",
+    "\n",
+    "5. **Results**:\n",
+    "   - `results.best(n, metric)` - Get top N by K-S statistic (default), A-D statistic, SSE, AIC, or BIC\n",
+    "   - `results.filter(ks_threshold, pvalue_threshold, ad_threshold)` - Filter by goodness-of-fit\n",
+    "   - `results.df.toPandas()` - Convert to pandas DataFrame\n",
+    "   - `DistributionFitResult.sample()`, `.pdf()`, `.cdf()` - Use fitted distribution\n",
+    "   - `DistributionFitResult.get_param_names()` - Get parameter names\n",
+    "   - `DistributionFitResult.confidence_intervals()` - Bootstrap confidence intervals\n",
+    "\n",
+    "6. **Lazy Metrics (v1.5.0+)**:\n",
+    "   - `lazy_metrics=True` - Skip KS/AD computation during fitting for faster iteration\n",
+    "   - `results.is_lazy` - Check if results have lazy metrics\n",
+    "   - `results.best(metric=\"ks_statistic\")` - Triggers on-demand computation for top candidates only\n",
+    "   - `results.materialize()` - Force computation of all KS/AD statistics\n",
+    "\n",
+    "7. **Multi-Column Fitting**:\n",
+    "   - `fitter.fit(df, columns=[...])` - Fit multiple columns in one call\n",
+    "   - `results.column_names` - List all fitted columns\n",
+    "   - `results.for_column(name)` - Filter results to one column\n",
+    "   - `results.best_per_column(n, metric)` - Get top N per column\n",
+    "\n",
+    "8. **Plotting**:\n",
+    "   - `fitter.plot()` - Visualize fitted distribution with data histogram\n",
+    "   - `fitter.plot_qq()` - Q-Q plot for visual goodness-of-fit assessment\n",
+    "   - `fitter.plot_pp()` - P-P plot for assessing fit in the center of distribution\n",
+    "   - Customizable with `figsize`, `dpi`, `histogram_alpha`, `pdf_linewidth`, etc.\n",
+    "\n",
+    "9. **Serialization**:\n",
+    "   - `result.save(path)` - Save to JSON (default) or pickle format\n",
+    "   - `DistributionFitResult.load(path)` - Load a saved result\n",
+    "   - `result.data_summary` - Access fitting statistics for provenance\n",
+    "   - JSON format includes version metadata for compatibility\n",
+    "\n",
+    "10. **Goodness-of-Fit Metrics**:\n",
+    "    - **K-S statistic** (default) - Lower is better, measures max distance from empirical CDF\n",
+    "    - **A-D statistic** - Lower is better, more sensitive to tails than K-S\n",
+    "    - **p-value** - Higher is better (>0.05 suggests good fit)\n",
+    "    - **A-D p-value** - Only available for norm, expon, logistic, gumbel_r, gumbel_l\n",
+    "    - **SSE** - Sum of squared errors between histogram and fitted PDF\n",
+    "    - **AIC/BIC** - Information criteria for model comparison"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T16:57:02.730332Z",
-     "iopub.status.busy": "2025-12-31T16:57:02.730283Z",
-     "iopub.status.idle": "2025-12-31T16:57:03.716424Z",
-     "shell.execute_reply": "2025-12-31T16:57:03.715258Z"
+     "iopub.execute_input": "2026-01-01T14:37:05.003781Z",
+     "iopub.status.busy": "2026-01-01T14:37:05.003732Z",
+     "iopub.status.idle": "2026-01-01T14:37:05.989200Z",
+     "shell.execute_reply": "2026-01-01T14:37:05.988245Z"
     }
    },
    "outputs": [

--- a/examples/bounded_demo.ipynb
+++ b/examples/bounded_demo.ipynb
@@ -37,10 +37,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:13.513536Z",
-     "iopub.status.busy": "2025-12-31T17:05:13.513382Z",
-     "iopub.status.idle": "2025-12-31T17:05:15.513620Z",
-     "shell.execute_reply": "2025-12-31T17:05:15.513152Z"
+     "iopub.execute_input": "2026-01-01T14:44:12.874829Z",
+     "iopub.status.busy": "2026-01-01T14:44:12.874760Z",
+     "iopub.status.idle": "2026-01-01T14:44:15.508577Z",
+     "shell.execute_reply": "2026-01-01T14:44:15.508126Z"
     }
    },
    "outputs": [
@@ -56,8 +56,8 @@
      "output_type": "stream",
      "text": [
       "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
-      "26/01/01 00:05:13 WARN Utils: Your hostname, 2025m5.local, resolves to a loopback address: 127.0.0.1; using 192.168.1.201 instead (on interface en0)\n",
-      "26/01/01 00:05:13 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "26/01/01 21:44:13 WARN Utils: Your hostname, 2025m5.local, resolves to a loopback address: 127.0.0.1; using 192.168.1.201 instead (on interface en0)\n",
+      "26/01/01 21:44:13 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
       "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
@@ -67,7 +67,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "26/01/01 00:05:14 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "26/01/01 21:44:13 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "26/01/01 21:44:14 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n"
      ]
     },
     {
@@ -100,10 +107,10 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:15.514669Z",
-     "iopub.status.busy": "2025-12-31T17:05:15.514544Z",
-     "iopub.status.idle": "2025-12-31T17:05:15.832742Z",
-     "shell.execute_reply": "2025-12-31T17:05:15.832374Z"
+     "iopub.execute_input": "2026-01-01T14:44:15.509776Z",
+     "iopub.status.busy": "2026-01-01T14:44:15.509628Z",
+     "iopub.status.idle": "2026-01-01T14:44:15.906140Z",
+     "shell.execute_reply": "2026-01-01T14:44:15.905682Z"
     }
    },
    "outputs": [],
@@ -139,10 +146,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:15.834148Z",
-     "iopub.status.busy": "2025-12-31T17:05:15.834053Z",
-     "iopub.status.idle": "2025-12-31T17:05:16.139766Z",
-     "shell.execute_reply": "2025-12-31T17:05:16.139300Z"
+     "iopub.execute_input": "2026-01-01T14:44:15.907523Z",
+     "iopub.status.busy": "2026-01-01T14:44:15.907421Z",
+     "iopub.status.idle": "2026-01-01T14:44:16.235036Z",
+     "shell.execute_reply": "2026-01-01T14:44:16.234622Z"
     }
    },
    "outputs": [
@@ -187,10 +194,10 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:16.140790Z",
-     "iopub.status.busy": "2025-12-31T17:05:16.140719Z",
-     "iopub.status.idle": "2025-12-31T17:05:20.194303Z",
-     "shell.execute_reply": "2025-12-31T17:05:20.193854Z"
+     "iopub.execute_input": "2026-01-01T14:44:16.236110Z",
+     "iopub.status.busy": "2026-01-01T14:44:16.236043Z",
+     "iopub.status.idle": "2026-01-01T14:44:20.800519Z",
+     "shell.execute_reply": "2026-01-01T14:44:20.800165Z"
     }
    },
    "outputs": [
@@ -206,7 +213,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 0:>                                                        (0 + 10) / 10]\r",
+      "[Stage 0:>                                                        (0 + 10) / 10]\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "\r",
       "                                                                                \r"
      ]
@@ -223,6 +236,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "[Stage 18:=======================================>                 (7 + 3) / 10]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -273,10 +288,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:20.195348Z",
-     "iopub.status.busy": "2025-12-31T17:05:20.195284Z",
-     "iopub.status.idle": "2025-12-31T17:05:21.340101Z",
-     "shell.execute_reply": "2025-12-31T17:05:21.339728Z"
+     "iopub.execute_input": "2026-01-01T14:44:20.801504Z",
+     "iopub.status.busy": "2026-01-01T14:44:20.801438Z",
+     "iopub.status.idle": "2026-01-01T14:44:21.967442Z",
+     "shell.execute_reply": "2026-01-01T14:44:21.967030Z"
     }
    },
    "outputs": [
@@ -330,10 +345,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:21.341114Z",
-     "iopub.status.busy": "2025-12-31T17:05:21.341051Z",
-     "iopub.status.idle": "2025-12-31T17:05:22.241832Z",
-     "shell.execute_reply": "2025-12-31T17:05:22.241313Z"
+     "iopub.execute_input": "2026-01-01T14:44:21.968484Z",
+     "iopub.status.busy": "2026-01-01T14:44:21.968417Z",
+     "iopub.status.idle": "2026-01-01T14:44:22.896911Z",
+     "shell.execute_reply": "2026-01-01T14:44:22.896533Z"
     }
    },
    "outputs": [
@@ -391,10 +406,10 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:22.243327Z",
-     "iopub.status.busy": "2025-12-31T17:05:22.243250Z",
-     "iopub.status.idle": "2025-12-31T17:05:22.253862Z",
-     "shell.execute_reply": "2025-12-31T17:05:22.253527Z"
+     "iopub.execute_input": "2026-01-01T14:44:22.897928Z",
+     "iopub.status.busy": "2026-01-01T14:44:22.897858Z",
+     "iopub.status.idle": "2026-01-01T14:44:22.907984Z",
+     "shell.execute_reply": "2026-01-01T14:44:22.907735Z"
     }
    },
    "outputs": [
@@ -442,10 +457,10 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:22.254888Z",
-     "iopub.status.busy": "2025-12-31T17:05:22.254826Z",
-     "iopub.status.idle": "2025-12-31T17:05:22.380371Z",
-     "shell.execute_reply": "2025-12-31T17:05:22.379868Z"
+     "iopub.execute_input": "2026-01-01T14:44:22.909075Z",
+     "iopub.status.busy": "2026-01-01T14:44:22.909004Z",
+     "iopub.status.idle": "2026-01-01T14:44:23.066069Z",
+     "shell.execute_reply": "2026-01-01T14:44:23.065618Z"
     }
    },
    "outputs": [],
@@ -460,10 +475,10 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:22.381504Z",
-     "iopub.status.busy": "2025-12-31T17:05:22.381408Z",
-     "iopub.status.idle": "2025-12-31T17:05:22.596250Z",
-     "shell.execute_reply": "2025-12-31T17:05:22.595868Z"
+     "iopub.execute_input": "2026-01-01T14:44:23.067281Z",
+     "iopub.status.busy": "2026-01-01T14:44:23.067179Z",
+     "iopub.status.idle": "2026-01-01T14:44:23.285315Z",
+     "shell.execute_reply": "2026-01-01T14:44:23.284921Z"
     }
    },
    "outputs": [
@@ -504,7 +519,15 @@
    "source": [
     "## 1.7 Compare: Unbounded vs Bounded Sampling\n",
     "\n",
-    "Without bounds, samples can exceed natural limits."
+    "The key benefit of bounded fitting: **samples never exceed natural limits**.\n",
+    "\n",
+    "When data is bounded (like test scores 0-100) but you fit an unbounded distribution \n",
+    "(like normal), samples can exceed the valid range. This is problematic for:\n",
+    "- Simulation/monte carlo that requires valid values\n",
+    "- Downstream systems that expect values within bounds\n",
+    "- Data quality validation\n",
+    "\n",
+    "Below we demonstrate this with test score data:"
    ]
   },
   {
@@ -513,10 +536,10 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:22.597317Z",
-     "iopub.status.busy": "2025-12-31T17:05:22.597241Z",
-     "iopub.status.idle": "2025-12-31T17:05:23.642769Z",
-     "shell.execute_reply": "2025-12-31T17:05:23.642256Z"
+     "iopub.execute_input": "2026-01-01T14:44:23.286467Z",
+     "iopub.status.busy": "2026-01-01T14:44:23.286392Z",
+     "iopub.status.idle": "2026-01-01T14:44:26.530633Z",
+     "shell.execute_reply": "2026-01-01T14:44:26.530276Z"
     }
    },
    "outputs": [
@@ -524,45 +547,106 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Comparison: Bounded vs Unbounded Sampling\n",
+      "Test score data (clipped normal):\n",
+      "  Min: 13.0, Max: 100.0, Mean: 70.0\n",
       "\n",
-      "Bounded (beta):\n",
-      "  Min: 0.07, Max: 90.25\n",
-      "  Samples < 0: 0\n",
+      "Fitting with bounds [0, 100]...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting unbounded (excluding beta to show infinite-support behavior)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "Comparison: Bounded vs Unbounded Sampling\n",
+      "============================================================\n",
+      "\n",
+      "BOUNDED (beta):\n",
+      "  Bounds: [0.0, 100.0]\n",
+      "  Sample range: [15.56, 100.00]\n",
+      "  Samples < 0:   0\n",
       "  Samples > 100: 0\n",
       "\n",
-      "Unbounded (beta):\n",
-      "  Min: 0.04, Max: 86.26\n",
-      "  Samples < 0: 0\n",
-      "  Samples > 100: 0\n"
+      "UNBOUNDED (burr12):\n",
+      "  Sample range: [8.23, 122.40]\n",
+      "  Samples < 0:   0 ← Invalid percentages!\n",
+      "  Samples > 100: 724 ← Invalid percentages!\n",
+      "\n",
+      "⚠️  1.4% of unbounded samples are outside valid range [0, 100]\n"
      ]
     }
    ],
    "source": [
-    "# Fit WITHOUT bounds\n",
-    "results_unbounded = fitter.fit(\n",
-    "    df_pct,\n",
-    "    column=\"conversion_rate\",\n",
-    "    bounded=False,  # No bounds\n",
-    "    max_distributions=10,\n",
+    "# To demonstrate bounded vs unbounded, we need data where unbounded fitting\n",
+    "# would select a distribution with INFINITE support (like normal).\n",
+    "# Beta-distributed data naturally fits beta, which has finite support.\n",
+    "\n",
+    "# Let's use normally-distributed test scores (bell-shaped, bounded to [0, 100])\n",
+    "np.random.seed(123)\n",
+    "test_scores = np.random.normal(70, 15, size=10_000)\n",
+    "test_scores = np.clip(test_scores, 0, 100)  # Real test scores are bounded\n",
+    "df_scores = spark.createDataFrame([(float(x),) for x in test_scores], [\"test_score\"])\n",
+    "\n",
+    "print(\"Test score data (clipped normal):\")\n",
+    "print(f\"  Min: {test_scores.min():.1f}, Max: {test_scores.max():.1f}, Mean: {test_scores.mean():.1f}\")\n",
+    "\n",
+    "# Create a fitter that EXCLUDES beta to force selection of infinite-support distributions\n",
+    "fitter_no_beta = DistributionFitter(\n",
+    "    spark,\n",
+    "    excluded_distributions=(\"beta\", \"betaprime\", \"truncnorm\", \"truncexpon\")\n",
     ")\n",
     "\n",
+    "# Bounded fit - uses full distribution set, respects [0, 100]\n",
+    "print(\"\\nFitting with bounds [0, 100]...\")\n",
+    "results_bounded = fitter.fit(\n",
+    "    df_scores,\n",
+    "    column=\"test_score\",\n",
+    "    bounded=True,\n",
+    "    lower_bound=0.0,\n",
+    "    upper_bound=100.0,\n",
+    "    max_distributions=15,\n",
+    ")\n",
+    "best_bounded = results_bounded.best(n=1)[0]\n",
+    "\n",
+    "# Unbounded fit - excludes beta to show what happens with infinite-support distributions\n",
+    "print(\"Fitting unbounded (excluding beta to show infinite-support behavior)...\")\n",
+    "results_unbounded = fitter_no_beta.fit(\n",
+    "    df_scores,\n",
+    "    column=\"test_score\",\n",
+    "    bounded=False,\n",
+    "    max_distributions=15,\n",
+    ")\n",
     "best_unbounded = results_unbounded.best(n=1)[0]\n",
     "\n",
     "# Sample from both\n",
-    "samples_bounded = best_explicit.sample(size=50_000, random_state=42)\n",
+    "samples_bounded = best_bounded.sample(size=50_000, random_state=42)\n",
     "samples_unbounded = best_unbounded.sample(size=50_000, random_state=42)\n",
     "\n",
+    "print(\"\\n\" + \"=\"*60)\n",
     "print(\"Comparison: Bounded vs Unbounded Sampling\")\n",
-    "print(f\"\\nBounded ({best_explicit.distribution}):\")\n",
-    "print(f\"  Min: {samples_bounded.min():.2f}, Max: {samples_bounded.max():.2f}\")\n",
-    "print(f\"  Samples < 0: {(samples_bounded < 0).sum()}\")\n",
-    "print(f\"  Samples > 100: {(samples_bounded > 100).sum()}\")\n",
+    "print(\"=\"*60)\n",
     "\n",
-    "print(f\"\\nUnbounded ({best_unbounded.distribution}):\")\n",
-    "print(f\"  Min: {samples_unbounded.min():.2f}, Max: {samples_unbounded.max():.2f}\")\n",
-    "print(f\"  Samples < 0: {(samples_unbounded < 0).sum()}\")\n",
-    "print(f\"  Samples > 100: {(samples_unbounded > 100).sum()}\")"
+    "print(f\"\\nBOUNDED ({best_bounded.distribution}):\")\n",
+    "print(f\"  Bounds: [{best_bounded.lower_bound}, {best_bounded.upper_bound}]\")\n",
+    "print(f\"  Sample range: [{samples_bounded.min():.2f}, {samples_bounded.max():.2f}]\")\n",
+    "print(f\"  Samples < 0:   {(samples_bounded < 0).sum():,}\")\n",
+    "print(f\"  Samples > 100: {(samples_bounded > 100).sum():,}\")\n",
+    "\n",
+    "print(f\"\\nUNBOUNDED ({best_unbounded.distribution}):\")\n",
+    "print(f\"  Sample range: [{samples_unbounded.min():.2f}, {samples_unbounded.max():.2f}]\")\n",
+    "print(f\"  Samples < 0:   {(samples_unbounded < 0).sum():,} ← Invalid percentages!\")\n",
+    "print(f\"  Samples > 100: {(samples_unbounded > 100).sum():,} ← Invalid percentages!\")\n",
+    "\n",
+    "pct_invalid = ((samples_unbounded < 0).sum() + (samples_unbounded > 100).sum()) / len(samples_unbounded) * 100\n",
+    "print(f\"\\n⚠️  {pct_invalid:.1f}% of unbounded samples are outside valid range [0, 100]\")"
    ]
   },
   {
@@ -583,10 +667,10 @@
    "id": "cell-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:23.643957Z",
-     "iopub.status.busy": "2025-12-31T17:05:23.643879Z",
-     "iopub.status.idle": "2025-12-31T17:05:23.667074Z",
-     "shell.execute_reply": "2025-12-31T17:05:23.666786Z"
+     "iopub.execute_input": "2026-01-01T14:44:26.532100Z",
+     "iopub.status.busy": "2026-01-01T14:44:26.531977Z",
+     "iopub.status.idle": "2026-01-01T14:44:26.556319Z",
+     "shell.execute_reply": "2026-01-01T14:44:26.555859Z"
     }
    },
    "outputs": [
@@ -619,10 +703,10 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:23.668222Z",
-     "iopub.status.busy": "2025-12-31T17:05:23.668154Z",
-     "iopub.status.idle": "2025-12-31T17:05:26.093719Z",
-     "shell.execute_reply": "2025-12-31T17:05:26.093379Z"
+     "iopub.execute_input": "2026-01-01T14:44:26.557272Z",
+     "iopub.status.busy": "2026-01-01T14:44:26.557212Z",
+     "iopub.status.idle": "2026-01-01T14:44:28.969794Z",
+     "shell.execute_reply": "2026-01-01T14:44:28.969511Z"
     }
    },
    "outputs": [
@@ -638,7 +722,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 148:==================================================>     (9 + 1) / 10]\r",
+      "[Stage 199:==================================================>     (9 + 1) / 10]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -648,7 +732,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 154:==================================================>     (9 + 1) / 10]\r"
+      "[Stage 205:==================================================>     (9 + 1) / 10]\r"
      ]
     },
     {
@@ -656,7 +740,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[Stage 156:===================================================>   (15 + 1) / 16]\r"
+      "[Stage 207:===================================================>   (15 + 1) / 16]\r"
      ]
     },
     {
@@ -703,10 +787,10 @@
    "id": "cell-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:26.094770Z",
-     "iopub.status.busy": "2025-12-31T17:05:26.094704Z",
-     "iopub.status.idle": "2025-12-31T17:05:26.214759Z",
-     "shell.execute_reply": "2025-12-31T17:05:26.214489Z"
+     "iopub.execute_input": "2026-01-01T14:44:28.970939Z",
+     "iopub.status.busy": "2026-01-01T14:44:28.970877Z",
+     "iopub.status.idle": "2026-01-01T14:44:29.086484Z",
+     "shell.execute_reply": "2026-01-01T14:44:29.086129Z"
     }
    },
    "outputs": [
@@ -753,10 +837,10 @@
    "id": "cell-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:26.215994Z",
-     "iopub.status.busy": "2025-12-31T17:05:26.215922Z",
-     "iopub.status.idle": "2025-12-31T17:05:26.219764Z",
-     "shell.execute_reply": "2025-12-31T17:05:26.219417Z"
+     "iopub.execute_input": "2026-01-01T14:44:29.087699Z",
+     "iopub.status.busy": "2026-01-01T14:44:29.087621Z",
+     "iopub.status.idle": "2026-01-01T14:44:29.091458Z",
+     "shell.execute_reply": "2026-01-01T14:44:29.091077Z"
     }
    },
    "outputs": [
@@ -764,7 +848,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saved bounded model to: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmp5pscoa9t/bounded_model.json\n",
+      "Saved bounded model to: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpijafl5s7/bounded_model.json\n",
       "\n",
       "Loaded model:\n",
       "  Distribution: beta\n",
@@ -808,10 +892,10 @@
    "id": "cell-26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:26.220629Z",
-     "iopub.status.busy": "2025-12-31T17:05:26.220569Z",
-     "iopub.status.idle": "2025-12-31T17:05:26.222172Z",
-     "shell.execute_reply": "2025-12-31T17:05:26.221895Z"
+     "iopub.execute_input": "2026-01-01T14:44:29.092345Z",
+     "iopub.status.busy": "2026-01-01T14:44:29.092290Z",
+     "iopub.status.idle": "2026-01-01T14:44:29.093886Z",
+     "shell.execute_reply": "2026-01-01T14:44:29.093617Z"
     }
    },
    "outputs": [
@@ -822,8 +906,8 @@
       "JSON file content (note lower_bound and upper_bound fields):\n",
       "{\n",
       "  \"schema_version\": \"1.1\",\n",
-      "  \"spark_bestfit_version\": \"1.3.2\",\n",
-      "  \"created_at\": \"2025-12-31T17:05:26.216872+00:00\",\n",
+      "  \"spark_bestfit_version\": \"1.5.0\",\n",
+      "  \"created_at\": \"2026-01-01T14:44:29.088570+00:00\",\n",
       "  \"distribution\": \"beta\",\n",
       "  \"parameters\": [\n",
       "    2.017523765563965,\n",
@@ -869,10 +953,10 @@
    "id": "cell-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:26.222951Z",
-     "iopub.status.busy": "2025-12-31T17:05:26.222898Z",
-     "iopub.status.idle": "2025-12-31T17:05:26.224551Z",
-     "shell.execute_reply": "2025-12-31T17:05:26.224289Z"
+     "iopub.execute_input": "2026-01-01T14:44:29.094766Z",
+     "iopub.status.busy": "2026-01-01T14:44:29.094695Z",
+     "iopub.status.idle": "2026-01-01T14:44:29.096451Z",
+     "shell.execute_reply": "2026-01-01T14:44:29.096121Z"
     }
    },
    "outputs": [
@@ -880,7 +964,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cleaned up: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmp5pscoa9t\n"
+      "Cleaned up: /var/folders/qb/4j7gq6v12kd770c_x85fhggw0000gn/T/tmpijafl5s7\n"
      ]
     }
    ],
@@ -915,10 +999,10 @@
    "id": "cell-30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:26.225534Z",
-     "iopub.status.busy": "2025-12-31T17:05:26.225485Z",
-     "iopub.status.idle": "2025-12-31T17:05:27.002379Z",
-     "shell.execute_reply": "2025-12-31T17:05:27.002006Z"
+     "iopub.execute_input": "2026-01-01T14:44:29.097352Z",
+     "iopub.status.busy": "2026-01-01T14:44:29.097300Z",
+     "iopub.status.idle": "2026-01-01T14:44:29.910168Z",
+     "shell.execute_reply": "2026-01-01T14:44:29.909798Z"
     }
    },
    "outputs": [
@@ -971,10 +1055,10 @@
    "id": "cell-32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:27.003404Z",
-     "iopub.status.busy": "2025-12-31T17:05:27.003321Z",
-     "iopub.status.idle": "2025-12-31T17:05:27.703400Z",
-     "shell.execute_reply": "2025-12-31T17:05:27.702978Z"
+     "iopub.execute_input": "2026-01-01T14:44:29.911286Z",
+     "iopub.status.busy": "2026-01-01T14:44:29.911204Z",
+     "iopub.status.idle": "2026-01-01T14:44:30.649992Z",
+     "shell.execute_reply": "2026-01-01T14:44:30.649537Z"
     }
    },
    "outputs": [
@@ -1017,48 +1101,232 @@
    "cell_type": "markdown",
    "id": "cell-33",
    "metadata": {},
-   "source": "---\n\n# Part 5: Per-Column Bounds (v1.5.0)\n\nStarting with v1.5.0, you can specify **different bounds for each column** in multi-column fitting."
-  },
-  {
-   "cell_type": "code",
-   "id": "jojwrt1a5fd",
-   "source": "# Create multi-column data with different natural bounds\nnp.random.seed(42)\n\n# Column 1: Percentage (0-100)\npct_data = np.random.beta(2, 5, size=3_000) * 100\n\n# Column 2: Price (non-negative, up to ~500)\nprice_data = np.random.exponential(scale=50, size=3_000)\n\n# Column 3: Age (0-120)\nage_data = np.random.gamma(shape=8, scale=5, size=3_000)\n\ndf_multi = spark.createDataFrame(\n    [(float(p), float(pr), float(a)) for p, pr, a in zip(pct_data, price_data, age_data)],\n    [\"percentage\", \"price\", \"age\"]\n)\n\nprint(\"Multi-column data with different natural bounds:\")\nprint(f\"  percentage: [{pct_data.min():.1f}, {pct_data.max():.1f}]\")\nprint(f\"  price:      [{price_data.min():.1f}, {price_data.max():.1f}]\")\nprint(f\"  age:        [{age_data.min():.1f}, {age_data.max():.1f}]\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "2w6bojxgn8j",
-   "source": "# Fit with per-column bounds using dictionaries (v1.5.0)\nprint(\"Fitting with per-column bounds...\")\n\nresults_per_col = fitter.fit(\n    df_multi,\n    columns=[\"percentage\", \"price\", \"age\"],\n    bounded=True,\n    lower_bound={\n        \"percentage\": 0.0,    # Percentages >= 0\n        \"price\": 0.0,         # Prices >= 0\n        \"age\": 0.0,           # Ages >= 0\n    },\n    upper_bound={\n        \"percentage\": 100.0,  # Percentages <= 100\n        \"price\": 1000.0,      # Prices capped at $1000\n        \"age\": 120.0,         # Ages <= 120\n    },\n    max_distributions=5,\n)\n\n# Check each column has its own bounds\nfor col in [\"percentage\", \"price\", \"age\"]:\n    best = results_per_col.for_column(col).best(n=1)[0]\n    print(f\"\\n{col}: {best.distribution}\")\n    print(f\"  Bounds: [{best.lower_bound}, {best.upper_bound}]\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "8cd1ln7cnh4",
-   "source": "# Verify samples respect column-specific bounds\nprint(\"Sampling verification - each column respects its own bounds:\\n\")\n\nfor col, expected_bounds in [(\"percentage\", (0, 100)), (\"price\", (0, 1000)), (\"age\", (0, 120))]:\n    best = results_per_col.for_column(col).best(n=1)[0]\n    samples = best.sample(size=5000, random_state=42)\n    \n    within = (samples >= expected_bounds[0]).all() and (samples <= expected_bounds[1]).all()\n    print(f\"{col}:\")\n    print(f\"  Sample range: [{samples.min():.2f}, {samples.max():.2f}]\")\n    print(f\"  Expected bounds: {expected_bounds}\")\n    print(f\"  All within bounds: {within}\\n\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5lji95tjffn",
-   "source": "---\n\n## Summary\n\nThis notebook demonstrated:\n\n1. **Auto-detect bounds**: `bounded=True` detects bounds from data min/max\n\n2. **Explicit bounds**: Specify `lower_bound` and/or `upper_bound` for domain knowledge\n\n3. **Partial bounds**: Specify only one bound (e.g., prices >= 0)\n\n4. **Sampling respects bounds**: All samples guaranteed within limits\n\n5. **Discrete support**: `DiscreteDistributionFitter` also supports bounded fitting\n\n6. **Serialization**: Bounds preserved when saving/loading models\n\n7. **Per-column bounds (v1.5.0)**: Use dictionaries to specify different bounds for each column\n\n### When to Use Bounded Fitting\n\n| Data Type | Typical Bounds |\n|-----------|---------------|\n| Percentages | [0, 100] or [0, 1] |\n| Prices | [0, ∞) |\n| Ages | [0, 120] |\n| Credit scores | [300, 850] |\n| Probabilities | [0, 1] |\n| Ratings | [1, 5] or [1, 10] |\n| Count ranges | [min, max] |",
-   "metadata": {}
+   "source": [
+    "---\n",
+    "\n",
+    "# Part 5: Per-Column Bounds (v1.5.0)\n",
+    "\n",
+    "Starting with v1.5.0, you can specify **different bounds for each column** in multi-column fitting."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "jojwrt1a5fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:44:30.650981Z",
+     "iopub.status.busy": "2026-01-01T14:44:30.650915Z",
+     "iopub.status.idle": "2026-01-01T14:44:30.677222Z",
+     "shell.execute_reply": "2026-01-01T14:44:30.676812Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Multi-column data with different natural bounds:\n",
+      "  percentage: [0.5, 82.0]\n",
+      "  price:      [0.0, 474.8]\n",
+      "  age:        [8.6, 93.9]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create multi-column data with different natural bounds\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "# Column 1: Percentage (0-100)\n",
+    "pct_data = np.random.beta(2, 5, size=3_000) * 100\n",
+    "\n",
+    "# Column 2: Price (non-negative, up to ~500)\n",
+    "price_data = np.random.exponential(scale=50, size=3_000)\n",
+    "\n",
+    "# Column 3: Age (0-120)\n",
+    "age_data = np.random.gamma(shape=8, scale=5, size=3_000)\n",
+    "\n",
+    "df_multi = spark.createDataFrame(\n",
+    "    [(float(p), float(pr), float(a)) for p, pr, a in zip(pct_data, price_data, age_data)],\n",
+    "    [\"percentage\", \"price\", \"age\"]\n",
+    ")\n",
+    "\n",
+    "print(\"Multi-column data with different natural bounds:\")\n",
+    "print(f\"  percentage: [{pct_data.min():.1f}, {pct_data.max():.1f}]\")\n",
+    "print(f\"  price:      [{price_data.min():.1f}, {price_data.max():.1f}]\")\n",
+    "print(f\"  age:        [{age_data.min():.1f}, {age_data.max():.1f}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "2w6bojxgn8j",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:44:30.678177Z",
+     "iopub.status.busy": "2026-01-01T14:44:30.678118Z",
+     "iopub.status.idle": "2026-01-01T14:44:32.097992Z",
+     "shell.execute_reply": "2026-01-01T14:44:32.097719Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting with per-column bounds...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "percentage: beta\n",
+      "  Bounds: [0.0, 100.0]\n",
+      "\n",
+      "price: beta\n",
+      "  Bounds: [0.0, 1000.0]\n",
+      "\n",
+      "age: beta\n",
+      "  Bounds: [0.0, 120.0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fit with per-column bounds using dictionaries (v1.5.0)\n",
+    "print(\"Fitting with per-column bounds...\")\n",
+    "\n",
+    "results_per_col = fitter.fit(\n",
+    "    df_multi,\n",
+    "    columns=[\"percentage\", \"price\", \"age\"],\n",
+    "    bounded=True,\n",
+    "    lower_bound={\n",
+    "        \"percentage\": 0.0,    # Percentages >= 0\n",
+    "        \"price\": 0.0,         # Prices >= 0\n",
+    "        \"age\": 0.0,           # Ages >= 0\n",
+    "    },\n",
+    "    upper_bound={\n",
+    "        \"percentage\": 100.0,  # Percentages <= 100\n",
+    "        \"price\": 1000.0,      # Prices capped at $1000\n",
+    "        \"age\": 120.0,         # Ages <= 120\n",
+    "    },\n",
+    "    max_distributions=5,\n",
+    ")\n",
+    "\n",
+    "# Check each column has its own bounds\n",
+    "for col in [\"percentage\", \"price\", \"age\"]:\n",
+    "    best = results_per_col.for_column(col).best(n=1)[0]\n",
+    "    print(f\"\\n{col}: {best.distribution}\")\n",
+    "    print(f\"  Bounds: [{best.lower_bound}, {best.upper_bound}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "8cd1ln7cnh4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-01T14:44:32.099092Z",
+     "iopub.status.busy": "2026-01-01T14:44:32.099028Z",
+     "iopub.status.idle": "2026-01-01T14:44:32.262136Z",
+     "shell.execute_reply": "2026-01-01T14:44:32.261850Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampling verification - each column respects its own bounds:\n",
+      "\n",
+      "percentage:\n",
+      "  Sample range: [0.63, 83.98]\n",
+      "  Expected bounds: (0, 100)\n",
+      "  All within bounds: True\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "price:\n",
+      "  Sample range: [0.04, 419.73]\n",
+      "  Expected bounds: (0, 1000)\n",
+      "  All within bounds: True\n",
+      "\n",
+      "age:\n",
+      "  Sample range: [9.45, 105.35]\n",
+      "  Expected bounds: (0, 120)\n",
+      "  All within bounds: True\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verify samples respect column-specific bounds\n",
+    "print(\"Sampling verification - each column respects its own bounds:\\n\")\n",
+    "\n",
+    "for col, expected_bounds in [(\"percentage\", (0, 100)), (\"price\", (0, 1000)), (\"age\", (0, 120))]:\n",
+    "    best = results_per_col.for_column(col).best(n=1)[0]\n",
+    "    samples = best.sample(size=5000, random_state=42)\n",
+    "    \n",
+    "    within = (samples >= expected_bounds[0]).all() and (samples <= expected_bounds[1]).all()\n",
+    "    print(f\"{col}:\")\n",
+    "    print(f\"  Sample range: [{samples.min():.2f}, {samples.max():.2f}]\")\n",
+    "    print(f\"  Expected bounds: {expected_bounds}\")\n",
+    "    print(f\"  All within bounds: {within}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5lji95tjffn",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "\n",
+    "1. **Auto-detect bounds**: `bounded=True` detects bounds from data min/max\n",
+    "\n",
+    "2. **Explicit bounds**: Specify `lower_bound` and/or `upper_bound` for domain knowledge\n",
+    "\n",
+    "3. **Partial bounds**: Specify only one bound (e.g., prices >= 0)\n",
+    "\n",
+    "4. **Sampling respects bounds**: All samples guaranteed within limits\n",
+    "\n",
+    "5. **Discrete support**: `DiscreteDistributionFitter` also supports bounded fitting\n",
+    "\n",
+    "6. **Serialization**: Bounds preserved when saving/loading models\n",
+    "\n",
+    "7. **Per-column bounds (v1.5.0)**: Use dictionaries to specify different bounds for each column\n",
+    "\n",
+    "### When to Use Bounded Fitting\n",
+    "\n",
+    "| Data Type | Typical Bounds |\n",
+    "|-----------|---------------|\n",
+    "| Percentages | [0, 100] or [0, 1] |\n",
+    "| Prices | [0, ∞) |\n",
+    "| Ages | [0, 120] |\n",
+    "| Credit scores | [300, 850] |\n",
+    "| Probabilities | [0, 1] |\n",
+    "| Ratings | [1, 5] or [1, 10] |\n",
+    "| Count ranges | [min, max] |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "id": "cell-34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-12-31T17:05:27.704458Z",
-     "iopub.status.busy": "2025-12-31T17:05:27.704389Z",
-     "iopub.status.idle": "2025-12-31T17:05:28.703378Z",
-     "shell.execute_reply": "2025-12-31T17:05:28.702438Z"
+     "iopub.execute_input": "2026-01-01T14:44:32.263273Z",
+     "iopub.status.busy": "2026-01-01T14:44:32.263204Z",
+     "iopub.status.idle": "2026-01-01T14:44:33.265575Z",
+     "shell.execute_reply": "2026-01-01T14:44:33.264681Z"
     }
    },
    "outputs": [
@@ -1078,7 +1346,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -1094,7 +1094,8 @@ class FitResults:
             filtered = filtered.filter(F.col("ad_statistic") < ad_threshold)
 
         # Preserve lazy contexts for the filtered results
-        return FitResults(filtered.cache(), lazy_contexts=self._lazy_contexts)
+        # Note: Don't cache here - parent DataFrame is already cached
+        return FitResults(filtered, lazy_contexts=self._lazy_contexts)
 
     def for_column(self, column_name: str) -> "FitResults":
         """Filter results to a single column.
@@ -1119,7 +1120,8 @@ class FitResults:
         if column_name in self._lazy_contexts:
             filtered_contexts[column_name] = self._lazy_contexts[column_name]
 
-        return FitResults(filtered.cache(), lazy_contexts=filtered_contexts)
+        # Note: Don't cache here - parent DataFrame is already cached
+        return FitResults(filtered, lazy_contexts=filtered_contexts)
 
     @property
     def column_names(self) -> List[str]:


### PR DESCRIPTION
## Summary
Remove redundant `.cache()` calls from `FitResults.filter()` and `for_column()` methods that triggered Spark CacheManager warnings.

## Related Issues
N/A

## Changes Made
- Remove `.cache()` from `FitResults.filter()` - parent DataFrame already cached
- Remove `.cache()` from `FitResults.for_column()` - parent DataFrame already cached
- Improve bounded_demo.ipynb comparison (unbounded now shows invalid samples)
- Refresh notebook outputs

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Testing
- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [x] Tested manually with example code

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally