### PR TITLE
docs: CI badge now shows main branch status only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spark-bestfit
 
-[![CI](https://github.com/dwsmith1983/spark-bestfit/actions/workflows/ci.yml/badge.svg)](https://github.com/dwsmith1983/spark-bestfit/actions/workflows/ci.yml)
+[![CI](https://github.com/dwsmith1983/spark-bestfit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dwsmith1983/spark-bestfit/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/spark-bestfit/badge/?version=latest)](https://spark-bestfit.readthedocs.io/en/latest/)
 [![PyPI version](https://img.shields.io/pypi/v/spark-bestfit)](https://pypi.org/project/spark-bestfit/)
 [![Production Ready](https://img.shields.io/badge/status-production--ready-brightgreen)](https://github.com/dwsmith1983/spark-bestfit)


### PR DESCRIPTION
## Summary

Fix CI badge to only show the status of the `main` branch, not failing PR checks.

## Related Issues

N/A - discovered during PR #82

## Changes Made

- Added `?branch=main` parameter to CI badge URL in README.md

## Type of Change

- [x] Documentation update

## Performance Impact

- [x] No performance impact expected

## Testing

- [x] Verified badge URL syntax is correct per GitHub docs

## Checklist

- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed