### PR TITLE
ci: add push trigger for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

CI now runs on both push to main and pull requests. This ensures the CI badge reflects the actual state of main after PRs are merged.

## Related Issues

Related to #83 (CI badge fix)

## Changes Made

- Added `push` trigger for `main` branch to CI workflow

## Type of Change

- [x] CI/CD or tooling changes

## Performance Impact

- [x] No performance impact expected

## Testing

- [x] Verified YAML syntax is valid

## Checklist

- [x] My code follows the project's style guidelines (`make check`)