### PR TITLE
ci: skip redundant tests on PR merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,15 @@ on:
 jobs:
   # Detect which paths changed to conditionally run jobs
   changes:
-    # Skip release commits - they only update version/changelog, already tested via PR
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    # Skip on push to main if:
+    # 1. Release commits (chore(release):) - only update version/changelog
+    # 2. PR merge commits (contain '(#') - already tested in PR
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        !startsWith(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '(#')
+      )
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
@@ -35,7 +42,13 @@ jobs:
               - 'pyproject.toml'
 
   pre-commit:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    # Same skip logic as changes job
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        !startsWith(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '(#')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Skip running full test suite on push to main when it's a PR merge commit, since those commits were already tested in the PR workflow.

## Related Issues
None

## Changes Made
- Updated `changes` job condition to skip PR merge commits (contain `(#`)
- Updated `pre-commit` job condition with same logic
- Always run for `pull_request` events, skip redundant runs on `push` to main

## Type of Change
- [x] CI/CD or tooling changes

## Performance Impact
- [x] Improves performance

Reduces CI minutes by ~50% on merges to main (skips redundant test runs).

## Testing
- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [ ] Tested manually with example code

Will verify after merge that:
1. PR CI runs normally
2. Push to main skips tests but `ci` job succeeds (for badges)

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed
- [x] All new and existing tests pass locally