### PR TITLE
docs: fix v2.5.0/v2.6.0 quality issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@
 
 ### Features
 
-- Add residual diagnostics plots ([#104](https://github.com/dwsmith1983/spark-bestfit/pull/104),
-  [`e2df9ff`](https://github.com/dwsmith1983/spark-bestfit/commit/e2df9ffd3434c06a7663eae806e75149e5efac04))
-
 - Add residual diagnostics plots and quality improvements
   ([#104](https://github.com/dwsmith1983/spark-bestfit/pull/104),
   [`e2df9ff`](https://github.com/dwsmith1983/spark-bestfit/commit/e2df9ffd3434c06a7663eae806e75149e5efac04))

--- a/docs/features/config.rst
+++ b/docs/features/config.rst
@@ -119,6 +119,27 @@ Builder Methods
    * - ``build()``
      - Create immutable ``FitterConfig``
 
+Estimation Method
+-----------------
+
+.. versionadded:: 2.5.0
+
+Configure the parameter estimation method:
+
+.. code-block:: python
+
+    config = (
+        FitterConfigBuilder()
+        .with_estimation_method('mse')  # or 'mle', 'auto'
+        .build()
+    )
+
+Options:
+
+- ``mle``: Maximum Likelihood Estimation (default)
+- ``mse``: Maximum Spacing Estimation (robust for heavy-tailed)
+- ``auto``: Automatically select based on data characteristics
+
 Config Attributes
 -----------------
 

--- a/docs/features/diagnostics-plots.rst
+++ b/docs/features/diagnostics-plots.rst
@@ -1,6 +1,8 @@
 Diagnostics Plots
 =================
 
+.. versionadded:: 2.6.0
+
 After fitting a distribution, you can assess the quality of the fit using
 diagnostic plots. spark-bestfit provides a comprehensive ``diagnostics()``
 method that creates a 2x2 panel of diagnostic visualizations.

--- a/docs/features/mse-estimation.rst
+++ b/docs/features/mse-estimation.rst
@@ -1,6 +1,8 @@
 Maximum Spacing Estimation
 ==========================
 
+.. versionadded:: 2.5.0
+
 spark-bestfit supports **Maximum Spacing Estimation (MSE)** as an alternative
 to Maximum Likelihood Estimation (MLE) for parameter fitting. MSE is particularly
 robust for heavy-tailed distributions where MLE may fail or produce poor estimates.

--- a/src/spark_bestfit/estimation.py
+++ b/src/spark_bestfit/estimation.py
@@ -22,7 +22,7 @@ from spark_bestfit.metrics import (
     compute_information_criteria_frozen,
     compute_ks_statistic_frozen,
 )
-from spark_bestfit.truncated import TruncatedFrozenDist, create_truncated_dist
+from spark_bestfit.truncated import create_truncated_dist
 
 # PySpark is optional - only import if available
 try:

--- a/src/spark_bestfit/metrics.py
+++ b/src/spark_bestfit/metrics.py
@@ -13,7 +13,7 @@ import numpy as np
 import scipy.stats as st
 from scipy.stats import rv_continuous
 
-from spark_bestfit.truncated import TruncatedFrozenDist, create_truncated_dist
+from spark_bestfit.truncated import create_truncated_dist
 
 # Distributions that support Anderson-Darling p-value computation via scipy
 # Maps our distribution names to scipy.anderson's dist parameter
@@ -65,9 +65,7 @@ def compute_information_criteria(
         return np.inf, np.inf
 
 
-def compute_information_criteria_frozen(
-    frozen_dist: Any, n_params: int, data: np.ndarray
-) -> Tuple[float, float]:
+def compute_information_criteria_frozen(frozen_dist: Any, n_params: int, data: np.ndarray) -> Tuple[float, float]:
     """Compute AIC and BIC information criteria using a frozen distribution.
 
     This version works with frozen (and possibly truncated) distributions,
@@ -104,9 +102,7 @@ def compute_information_criteria_frozen(
         return np.inf, np.inf
 
 
-def compute_ks_statistic(
-    dist: rv_continuous, params: Tuple[float, ...], data: np.ndarray
-) -> Tuple[float, float]:
+def compute_ks_statistic(dist: rv_continuous, params: Tuple[float, ...], data: np.ndarray) -> Tuple[float, float]:
     """Compute Kolmogorov-Smirnov statistic and p-value.
 
     The KS statistic measures the maximum distance between the empirical


### PR DESCRIPTION
## Summary
Fix documentation quality issues for v2.5.0 and v2.6.0 releases including CHANGELOG duplicates, missing version annotations, and undocumented config methods.

## Related Issues
N/A

## Changes Made
- Remove duplicate CHANGELOG entry for v2.6.0 "Add residual diagnostics plots"
- Add `.. versionadded:: 2.5.0` to docs/features/mse-estimation.rst
- Add `.. versionadded:: 2.6.0` to docs/features/diagnostics-plots.rst
- Add "Estimation Method" section to docs/features/config.rst documenting `with_estimation_method()` builder

## Type of Change
- [x] Documentation update

## Performance Impact
- [x] No performance impact expected

## Testing
- [x] All existing tests pass (`make test`)
- [x] Ran `make docs` to validate Sphinx build

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed
- [x] All new and existing tests pass locally