### PR TITLE
fix: use OR instead of AND for MSE fallback condition

### DIFF
--- a/src/spark_bestfit/fitting.py
+++ b/src/spark_bestfit/fitting.py
@@ -286,7 +286,7 @@ def fit_mse(
         options={"maxiter": 2000, "xatol": 1e-8, "fatol": 1e-8},
     )
 
-    if not result.success and result.fun == np.inf:
+    if not result.success or result.fun == np.inf:
         # Try with L-BFGS-B as fallback (handles bounds better)
         n_params = len(initial_params)
         # Set bounds: shape params unbounded, loc unbounded, scale > 0
@@ -299,7 +299,7 @@ def fit_mse(
             options={"maxiter": 2000},
         )
 
-    if not result.success and result.fun == np.inf:
+    if not result.success or result.fun == np.inf:
         raise ValueError(f"MSE optimization failed: {result.message}")
 
     return tuple(result.x)


### PR DESCRIPTION
## Summary
Fix the MSE fallback condition to use OR instead of AND, ensuring the L-BFGS-B fallback triggers when Nelder-Mead either fails OR returns infinity.

## Related Issues
Fixes #116

## Changes Made
- Changed `if not result.success and result.fun == np.inf:` to `if not result.success or result.fun == np.inf:` at line 289 (Nelder-Mead → L-BFGS-B fallback)
- Changed same condition at line 302 (final error check after L-BFGS-B)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Performance Impact
- [x] No performance impact expected

## Testing
- [x] All existing tests pass (`make test`)
- [x] Tested manually with example code

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [x] All new and existing tests pass locally

## Notes
The discrete_fitting.py:121 occurrence was intentionally NOT changed - it has different semantics (no fallback mechanism) and discrete optimization often returns success=False with a valid finite result when hitting maxiter.