### PR TITLE
chore: improve type checker compatibility for __all__ exports

### DIFF
--- a/src/spark_bestfit/__init__.py
+++ b/src/spark_bestfit/__init__.py
@@ -130,23 +130,21 @@ __all__ = [
 
 # Conditionally add SparkBackend to exports if pyspark is installed
 if _SPARK_AVAILABLE:
-    __all__.append("SparkBackend")
+    __all__ += ["SparkBackend"]
 
 # Conditionally add RayBackend to exports if ray is installed
 if _RAY_AVAILABLE:
-    __all__.append("RayBackend")
+    __all__ += ["RayBackend"]
 
 # Conditionally add plotting functions to exports if matplotlib is installed
 if _MATPLOTLIB_AVAILABLE:
-    __all__.extend(
-        [
-            "plot_distribution",
-            "plot_comparison",
-            "plot_qq",
-            "plot_pp",
-            "plot_discrete_distribution",
-            "plot_residual_histogram",
-            "plot_cdf_comparison",
-            "plot_diagnostics",
-        ]
-    )
+    __all__ += [
+        "plot_distribution",
+        "plot_comparison",
+        "plot_qq",
+        "plot_pp",
+        "plot_discrete_distribution",
+        "plot_residual_histogram",
+        "plot_cdf_comparison",
+        "plot_diagnostics",
+    ]

--- a/src/spark_bestfit/backends/__init__.py
+++ b/src/spark_bestfit/backends/__init__.py
@@ -35,7 +35,7 @@ __all__ = ["BackendFactory", "LocalBackend"]
 try:
     from spark_bestfit.backends.spark import SparkBackend  # noqa: F401
 
-    __all__.append("SparkBackend")
+    __all__ += ["SparkBackend"]
 except ImportError:
     pass  # PySpark not installed, SparkBackend not available
 
@@ -43,6 +43,6 @@ except ImportError:
 try:
     from spark_bestfit.backends.ray import RayBackend  # noqa: F401
 
-    __all__.append("RayBackend")
+    __all__ += ["RayBackend"]
 except ImportError:
     pass  # Ray not installed, RayBackend not available

--- a/src/spark_bestfit/fast_ppf.py
+++ b/src/spark_bestfit/fast_ppf.py
@@ -34,7 +34,6 @@ import numpy as np
 from scipy import special
 from scipy import stats as st
 
-
 # Type alias for PPF function signature
 PPFFunc = Callable[[np.ndarray, Tuple], np.ndarray]
 


### PR DESCRIPTION
## Summary
Improves static type checker compatibility by using list concatenation (`+=`) instead of `.append()`/`.extend()` when modifying `__all__` for optional dependencies.

## Related Issues
N/A - Code quality improvement

## Changes Made
- Changed `__all__.append("X")` to `__all__ += ["X"]` in `src/spark_bestfit/__init__.py`
- Changed `__all__.extend([...])` to `__all__ += [...]` in `src/spark_bestfit/__init__.py`
- Changed `__all__.append("X")` to `__all__ += ["X"]` in `src/spark_bestfit/backends/__init__.py`
- Fixed import ordering in `src/spark_bestfit/fast_ppf.py` (isort)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)
- [ ] CI/CD or tooling changes

## Performance Impact
- [x] No performance impact expected

## Testing
- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [ ] Tested manually with example code
- [ ] Ran benchmarks (`make benchmark`) - if performance-related
- [ ] Validated example notebooks (`make validate-notebooks`) - if API changes

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally