### PR TITLE
test: add pytest markers for CI test filtering

### DIFF
--- a/src/spark_bestfit/fast_ppf.py
+++ b/src/spark_bestfit/fast_ppf.py
@@ -34,7 +34,6 @@ import numpy as np
 from scipy import special
 from scipy import stats as st
 
-
 # Type alias for PPF function signature
 PPFFunc = Callable[[np.ndarray, Tuple], np.ndarray]
 

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -311,6 +311,7 @@ class TestFitResultsHierarchyProperties:
 class TestFittingOperationProperties:
     """Property-based tests for fitting operation invariants."""
 
+    @pytest.mark.slow
     @given(data=finite_float_array(min_size=100, max_size=500, min_value=0.1, max_value=1000))
     @settings(max_examples=15, deadline=None)
     def test_fitting_returns_finite_metrics(self, data):
@@ -362,6 +363,7 @@ class TestFittingOperationProperties:
         best = results.best(n=1, metric=metric)
         assert len(best) <= 1
 
+    @pytest.mark.slow
     @given(n=finite_float_array(min_size=100, max_size=300, min_value=1, max_value=100))
     @settings(max_examples=10, deadline=None)
     def test_filter_returns_subset(self, n):
@@ -586,6 +588,7 @@ class TestFitterConfigBuilderProperties:
 class TestFitterConfigIntegrationProperties:
     """Property-based tests for FitterConfig integration with fitters."""
 
+    @pytest.mark.slow
     @given(config=fitter_config(), data=finite_float_array(min_size=100, max_size=300))
     @settings(max_examples=10, deadline=None)
     def test_fit_with_config_does_not_raise(self, config, data):
@@ -610,6 +613,7 @@ class TestFitterConfigIntegrationProperties:
         results = fitter.fit(df, column="value", config=config)
         assert results.count() >= 0
 
+    @pytest.mark.slow
     @given(data=finite_float_array(min_size=100, max_size=200))
     @settings(max_examples=10, deadline=None)
     def test_config_vs_params_equivalence(self, data):

--- a/tests/test_spark_backend.py
+++ b/tests/test_spark_backend.py
@@ -2,11 +2,18 @@
 
 This module contains Spark-specific tests. All tests are skipped if PySpark
 is not installed, following the same pattern as test_ray_backend.py.
+
+Tests are marked with @pytest.mark.spark so CI can run them separately:
+    pytest -m spark       # Run only Spark tests
+    pytest -m "not spark" # Run without Spark tests
 """
 
 import numpy as np
 import pandas as pd
 import pytest
+
+# Mark all tests in this module as spark tests for CI filtering
+pytestmark = pytest.mark.spark
 
 # Skip all tests if pyspark not installed
 pyspark = pytest.importorskip("pyspark")


### PR DESCRIPTION
## Summary

Add pytest markers to improve CI test filtering and identify slow tests.

## Related Issues

Hook: hq-qzor - Chore: Testing improvements

## Changes Made

- Add `pytestmark = pytest.mark.spark` to `test_spark_backend.py` so Spark tests are properly collected when running `pytest -m spark` in CI
- Add `@pytest.mark.slow` to 4 property-based tests that perform actual distribution fitting operations
- Update module docstring to document marker usage

## Type of Change

- [x] CI/CD or tooling changes

## Performance Impact

- [x] No performance impact expected

## Testing

- [x] All existing tests pass (`make test`) - 1077 tests pass
- [x] Verified marker collection: `pytest -m spark --collect-only` now properly collects 127 Spark tests including all tests from `test_spark_backend.py`

## Checklist

- [x] My code follows the project's style guidelines (`make check`)
- [x] All new and existing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)