### PR TITLE
refactor: define NUMERICAL_EPSILON constant (GitHub #108)

### DIFF
--- a/src/spark_bestfit/fitting.py
+++ b/src/spark_bestfit/fitting.py
@@ -35,6 +35,7 @@ from spark_bestfit.estimation import (
 # Re-export everything from metrics module
 from spark_bestfit.metrics import (
     AD_PVALUE_DISTRIBUTIONS,
+    NUMERICAL_EPSILON,
     compute_ad_pvalue,
     compute_ad_statistic,
     compute_ad_statistic_frozen,
@@ -57,6 +58,7 @@ __all__ = [
     "FIT_RESULT_SCHEMA",
     "HEAVY_TAIL_DISTRIBUTIONS",
     "AD_PVALUE_DISTRIBUTIONS",
+    "NUMERICAL_EPSILON",
     "EstimationMethod",
     # Data analysis
     "compute_data_stats",

--- a/src/spark_bestfit/metrics.py
+++ b/src/spark_bestfit/metrics.py
@@ -15,6 +15,10 @@ from scipy.stats import rv_continuous
 
 from spark_bestfit.truncated import create_truncated_dist
 
+# Small value to prevent log(0) and division by zero in numerical computations.
+# Used for clipping CDF values and ensuring positive scale parameters.
+NUMERICAL_EPSILON: float = 1e-10
+
 # Distributions that support Anderson-Darling p-value computation via scipy
 # Maps our distribution names to scipy.anderson's dist parameter
 AD_PVALUE_DISTRIBUTIONS: Dict[str, str] = {
@@ -202,7 +206,7 @@ def compute_ad_statistic(dist: rv_continuous, params: Tuple[float, ...], data: n
         cdf_values = dist.cdf(sorted_data, *params)
 
         # Clamp CDF values to avoid log(0) or log(negative)
-        cdf_values = np.clip(cdf_values, 1e-10, 1 - 1e-10)
+        cdf_values = np.clip(cdf_values, NUMERICAL_EPSILON, 1 - NUMERICAL_EPSILON)
 
         # Compute A-D statistic using the formula
         # A^2 = -n - (1/n) sum_i (2i-1)[ln F(X_i) + ln(1-F(X_{n+1-i}))]
@@ -244,7 +248,7 @@ def compute_ad_statistic_frozen(frozen_dist: Any, data: np.ndarray) -> float:
         cdf_values = frozen_dist.cdf(sorted_data)
 
         # Clamp CDF values to avoid log(0) or log(negative)
-        cdf_values = np.clip(cdf_values, 1e-10, 1 - 1e-10)
+        cdf_values = np.clip(cdf_values, NUMERICAL_EPSILON, 1 - NUMERICAL_EPSILON)
 
         # Compute A-D statistic using the formula
         # A^2 = -n - (1/n) sum_i (2i-1)[ln F(X_i) + ln(1-F(X_{n+1-i}))]


### PR DESCRIPTION
## Summary
- Define module-level `NUMERICAL_EPSILON` constant (1e-10) for numerical stability
- Replace all hardcoded `1e-10` values in estimation.py and metrics.py
- Re-export from fitting.py for backward compatibility

## Changes
| File | Description |
|------|-------------|
| `metrics.py` | Added constant with docstring, updated 2 usages |
| `estimation.py` | Imported constant, updated 3 usages |
| `fitting.py` | Re-exported constant |

## Not Changed
- `histogram.py`: Uses `1e-10` for relative bin tolerance (different purpose)

## Test plan
- [x] All 1121 tests pass
- [x] `make check` passes (linters, formatters, mypy)
- [x] `make docs` builds successfully
- [x] No behavioral changes

Related: #108