### PR TITLE
test: benchmark fast_ppf performance claims (GitHub #117)

### DIFF
--- a/src/spark_bestfit/fast_ppf.py
+++ b/src/spark_bestfit/fast_ppf.py
@@ -3,9 +3,23 @@
 This module provides optimized PPF computations for common distributions,
 bypassing scipy.stats overhead by calling scipy.special functions directly.
 
-The standard scipy.stats.rv_continuous.ppf() uses iterative root-finding,
-which adds ~28x overhead compared to direct formulas. This module implements
-closed-form PPFs for distributions where they exist.
+The scipy.stats.rv_continuous.ppf() machinery adds overhead for parameter
+validation, bounds checking, and generic handling. This module provides
+direct implementations that skip this overhead where possible.
+
+Performance improvements vary by distribution (benchmarked with 100K elements):
+
+    - uniform:     ~16x faster (trivial linear transformation)
+    - weibull_min: ~2.7x faster (closed-form using log1p)
+    - expon:       ~2.3x faster (closed-form using log1p)
+    - norm:        ~1.5x faster (direct ndtri call)
+    - lognorm:     ~1.3x faster (exp of ndtri)
+    - gamma:       ~1.0x (same scipy.special function as scipy.stats)
+    - beta:        ~1.0x (same scipy.special function as scipy.stats)
+
+Note: Gamma and beta use scipy.special.gammaincinv/betaincinv which are
+the same numerical routines used by scipy.stats, so no speedup is expected.
+The main benefit for these distributions is API consistency.
 
 Supported distributions with fast PPF:
     - norm: Normal/Gaussian


### PR DESCRIPTION
## Summary
- Benchmarked fast_ppf performance claims from PR #113
- Updated documentation with actual measured speedups
- Replaced weak test assertion with meaningful performance tests

## Key Findings
The original 28x speedup claim was **overstated**. Actual measurements (100K elements):

| Distribution | Speedup | Reason |
|-------------|---------|--------|
| uniform | ~16x | Trivial linear transformation |
| weibull_min | ~2.7x | Closed-form using log1p |
| expon | ~2.3x | Closed-form using log1p |
| norm | ~1.5x | Direct ndtri call |
| lognorm | ~1.3x | exp(s * ndtri(q)) |
| gamma | ~1.0x | Same scipy.special.gammaincinv |
| beta | ~1.0x | Same scipy.special.betaincinv |

Gamma and beta show no speedup because they use the same `scipy.special` functions internally.

## Test plan
- [x] `make check` passes (pre-commit + 1123 tests)
- [x] `make docs` builds successfully
- [x] New performance tests validate expected speedups
- [x] Benchmarks can be run with: `pytest tests/benchmarks/test_benchmark_fast_ppf.py -v --benchmark-only`

Related: #117