### PR TITLE
feat(types): add histogram type aliases for IDE autocomplete

### DIFF
--- a/src/spark_bestfit/__init__.py
+++ b/src/spark_bestfit/__init__.py
@@ -72,6 +72,9 @@ from spark_bestfit.results import (  # Collection classes; Data classes; Type al
     EagerFitResults,
     FitResults,
     FitResultsType,
+    HistogramBins,
+    HistogramCounts,
+    HistogramResult,
     LazyFitResults,
     MetricName,
 )
@@ -130,6 +133,9 @@ __all__ = [
     "MetricName",
     "ContinuousHistogram",
     "DiscreteHistogram",
+    "HistogramBins",
+    "HistogramCounts",
+    "HistogramResult",
     # Constants
     "FITTING_SAMPLE_SIZE",
     "DEFAULT_PVALUE_THRESHOLD",

--- a/src/spark_bestfit/results.py
+++ b/src/spark_bestfit/results.py
@@ -22,6 +22,9 @@ Type Aliases:
     MetricName: Valid metric names for sorting/filtering.
     ContinuousHistogram: Tuple type for continuous distribution histograms.
     DiscreteHistogram: Tuple type for discrete distribution histograms.
+    HistogramBins: Array of bin edges (len = n_bins + 1).
+    HistogramCounts: Array of counts/density per bin.
+    HistogramResult: Tuple type for HistogramComputer results (counts, bins).
     FitResultsType: Union of EagerFitResults and LazyFitResults.
 
 Constants:
@@ -60,6 +63,9 @@ from spark_bestfit.storage import (  # Constants; Type aliases; Data classes
     ContinuousHistogram,
     DiscreteHistogram,
     DistributionFitResult,
+    HistogramBins,
+    HistogramCounts,
+    HistogramResult,
     LazyMetricsContext,
     MetricName,
 )
@@ -83,6 +89,9 @@ __all__ = [
     "MetricName",
     "ContinuousHistogram",
     "DiscreteHistogram",
+    "HistogramBins",
+    "HistogramCounts",
+    "HistogramResult",
     "FitResultsType",
     # Data classes
     "DistributionFitResult",

--- a/src/spark_bestfit/storage.py
+++ b/src/spark_bestfit/storage.py
@@ -12,6 +12,9 @@ Type Aliases:
     MetricName: Valid metric names for sorting/filtering.
     ContinuousHistogram: Tuple type for continuous distribution histograms.
     DiscreteHistogram: Tuple type for discrete distribution histograms.
+    HistogramBins: Array of bin edges (len = n_bins + 1).
+    HistogramCounts: Array of counts/density per bin.
+    HistogramResult: Tuple type for HistogramComputer results (counts, bins).
 
 Constants:
     FITTING_SAMPLE_SIZE: Default sample size for fitting (10000).
@@ -27,7 +30,7 @@ Constants:
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeAlias, Union
 
 import numpy as np
 import scipy.stats as st
@@ -83,6 +86,16 @@ ContinuousHistogram = Tuple[np.ndarray, np.ndarray]
 
 # DiscreteHistogram: (x_values, empirical_pmf) where both arrays have same length
 DiscreteHistogram = Tuple[np.ndarray, np.ndarray]
+
+# HistogramBins: Array of bin edges (len = n_bins + 1)
+HistogramBins: TypeAlias = np.ndarray
+
+# HistogramCounts: Array of counts/density per bin
+HistogramCounts: TypeAlias = np.ndarray
+
+# HistogramResult: Complete histogram from HistogramComputer.compute_histogram()
+# Order is (counts, bins) where counts has n_bins elements and bins has n_bins + 1 edges
+HistogramResult: TypeAlias = Tuple[np.ndarray, np.ndarray]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Add type aliases for histogram operations to enable better IDE autocomplete and type hints.

## Related Issues
Closes #138

## Changes Made
- Add `HistogramBins` type alias (np.ndarray) for bin edges
- Add `HistogramCounts` type alias (np.ndarray) for counts/density per bin
- Add `HistogramResult` type alias (Tuple[np.ndarray, np.ndarray]) for complete histogram
- Export all three from storage.py, results.py, and top-level __init__.py
- Use `TypeAlias` annotation for proper mypy support

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Performance Impact
- [x] No performance impact expected

## Testing
- [x] All existing tests pass (`make test`)
- [x] Tested manually with example code

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [x] I have updated the documentation if needed
- [x] All new and existing tests pass locally

## Screenshots / Examples
```python
from spark_bestfit import HistogramBins, HistogramCounts, HistogramResult

# Use in function signatures for precise type hints
def process_histogram(counts: HistogramCounts, bins: HistogramBins) -> None:
    ...

# Or use the complete result type
def compute_histogram(data: np.ndarray) -> HistogramResult:
    ...
```