### PR TITLE
fix(tests): prevent Spark session pollution between tests

### DIFF
--- a/tests/test_protocol_integration.py
+++ b/tests/test_protocol_integration.py
@@ -91,7 +91,7 @@ def spark_backend_fixture():
     )
     backend = SparkBackend(spark)
     yield backend
-    spark.stop()
+    # Don't stop session - let conftest.py session-scoped fixture handle cleanup
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,14 +39,10 @@ class TestGetSparkSession:
 
         assert df.count() == 3
 
-    def test_raises_error_when_no_session_available(self):
+    def test_raises_error_when_no_session_available(self, monkeypatch):
         """Test that RuntimeError is raised when no session is available."""
-        # Stop any existing session
-        existing = SparkSession.getActiveSession()
-        if existing:
-            existing.stop()
+        # Mock getActiveSession to return None instead of actually stopping
+        monkeypatch.setattr(SparkSession, "getActiveSession", lambda: None)
 
         with pytest.raises(RuntimeError, match="No SparkSession provided"):
             get_spark_session(None)
-
-        # Recreate session for other tests (fixture will handle this)


### PR DESCRIPTION
## Summary
Fix test isolation issues where Spark session was being stopped by one test module and causing subsequent tests to fail.

## Related Issues
Fixes 15 failed tests and 44 errors in full test suite run.

## Changes Made
- `tests/test_utils.py`: Use monkeypatch to mock `SparkSession.getActiveSession()` instead of actually stopping the session
- `tests/test_protocol_integration.py`: Remove `spark.stop()` from fixture teardown - let conftest.py handle cleanup

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] All existing tests pass (`make test`) - 1250 passed
- [x] Verified fix by running problematic test combinations

## Checklist
- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass locally