### PR TITLE
fix: exclude __init__.py from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ markers = [
 [tool.coverage.run]
 source = ["src/spark_bestfit"]
 branch = true
+omit = ["*/__init__.py"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## Summary
Exclude `__init__.py` files from coverage reporting. These files contain conditional imports for optional dependencies (Spark, Ray, matplotlib) that create branches difficult to cover without multiple test runs with different dependency combinations.

## Related Issues
None

## Changes Made
- Added `omit = ["*/__init__.py"]` to `[tool.coverage.run]` section in pyproject.toml

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] CI/CD or tooling changes

## Performance Impact
- [x] No performance impact expected
- [ ] Improves performance
- [ ] May impact performance (explain tradeoffs below)

## Testing
- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [ ] Tested manually with example code
- [ ] Ran benchmarks (`make benchmark`) - if performance-related
- [ ] Validated example notebooks (`make validate-notebooks`) - if API changes

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally