### PR TITLE
refactor: clean up pyproject.toml using Hatch template inheritance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,49 +140,33 @@ exclude_lines = [
 ]
 
 # Hatch test environments for cross-version testing
-[tool.hatch.envs.test]
+# Base environment with common test dependencies and scripts
+[tool.hatch.envs.hatch-test]
 dependencies = [
     "pytest>=8.3.0",
     "pytest-cov>=6.0.0",
     "pytest-spark>=0.6.0",
 ]
 
-[tool.hatch.envs.test.scripts]
-run = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
+[tool.hatch.envs.hatch-test.scripts]
+test = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
 
 # Spark 3.5 with Python 3.11
-[[tool.hatch.envs.test.matrix]]
-python = ["3.11"]
-spark = ["3.5"]
-
-[tool.hatch.envs.test.overrides]
-matrix.spark.dependencies = [
-    { value = "pyspark>=3.5.0,<4.0.0", if = ["3.5"] },
-    { value = "pyspark>=4.0.0,<5.0.0", if = ["4.0"] },
-]
-
-# Separate environments with explicit dependencies for each combo
 [tool.hatch.envs.spark35-py311]
+template = "hatch-test"
 python = "3.11"
-dependencies = [
-    "pytest>=8.3.0",
-    "pytest-cov>=6.0.0",
-    "pytest-spark>=0.6.0",
+extra-dependencies = [
     "pyspark>=3.5.0,<4.0.0",
     "numpy>=1.24.0,<2.0.0",
     "pandas>=1.5.0,<3.0.0",
     "pyarrow>=12.0.0,<17.0.0",
 ]
 
-[tool.hatch.envs.spark35-py311.scripts]
-test = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
-
+# Spark 3.5 with Python 3.12
 [tool.hatch.envs.spark35-py312]
+template = "hatch-test"
 python = "3.12"
-dependencies = [
-    "pytest>=8.3.0",
-    "pytest-cov>=6.0.0",
-    "pytest-spark>=0.6.0",
+extra-dependencies = [
     "pyspark>=3.5.0,<4.0.0",
     "numpy>=1.26.0,<2.0.0",
     "pandas>=2.0.0,<3.0.0",
@@ -190,38 +174,27 @@ dependencies = [
     "setuptools",  # Provides distutils for PySpark 3.5 on Python 3.12+
 ]
 
-[tool.hatch.envs.spark35-py312.scripts]
-test = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
-
+# Spark 4.0 with Python 3.12
 [tool.hatch.envs.spark40-py312]
+template = "hatch-test"
 python = "3.12"
-dependencies = [
-    "pytest>=8.3.0",
-    "pytest-cov>=6.0.0",
-    "pytest-spark>=0.6.0",
+extra-dependencies = [
     "pyspark>=4.0.0,<5.0.0",
     "numpy>=2.0.0,<3.0.0",
     "pandas>=2.2.0,<3.0.0",
     "pyarrow>=17.0.0,<19.0.0",
 ]
 
-[tool.hatch.envs.spark40-py312.scripts]
-test = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
-
+# Spark 4.0 with Python 3.13
 [tool.hatch.envs.spark40-py313]
+template = "hatch-test"
 python = "3.13"
-dependencies = [
-    "pytest>=8.3.0",
-    "pytest-cov>=6.0.0",
-    "pytest-spark>=0.6.0",
+extra-dependencies = [
     "pyspark>=4.0.0,<5.0.0",
     "numpy>=2.0.0,<3.0.0",
     "pandas>=2.2.0,<3.0.0",
     "pyarrow>=17.0.0,<19.0.0",
 ]
-
-[tool.hatch.envs.spark40-py313.scripts]
-test = "pytest --cov=src/spark_bestfit --cov-report=term-missing --cov-fail-under=85 -v {args}"
 
 # Semantic Release configuration
 [tool.semantic_release]


### PR DESCRIPTION
## Summary

Clean up pyproject.toml by removing dead Hatch matrix configuration and implementing template inheritance for spark test environments.

## Related Issues

N/A

## Changes Made

- Remove unused `[tool.hatch.envs.test]` with `[[tool.hatch.envs.test.matrix]]` section
- Add base `[tool.hatch.envs.hatch-test]` environment with common dependencies and test script
- Update spark35-py311, spark35-py312, spark40-py312, spark40-py313 to use `template = "hatch-test"`
- Change `dependencies` to `extra-dependencies` for version-specific packages
- Reduce pyproject.toml from 290 to 263 lines (9.3% reduction)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)
- [ ] CI/CD or tooling changes

## Performance Impact

- [x] No performance impact expected

## Testing

- [x] All existing tests pass (`make test`)
- [ ] Added new tests for the changes
- [ ] Tested manually with example code
- [ ] Ran benchmarks (`make benchmark`) - if performance-related
- [ ] Validated example notebooks (`make validate-notebooks`) - if API changes

## Checklist

- [x] My code follows the project's style guidelines (`make check`)
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)