### PR TITLE
test: increase fast_ppf.py coverage from 63% to 92%

### DIFF
--- a/tests/test_fast_ppf.py
+++ b/tests/test_fast_ppf.py
@@ -8,7 +8,12 @@ import numpy as np
 import pytest
 import scipy.stats as st
 
-from spark_bestfit.fast_ppf import fast_ppf, fast_ppf_batch, has_fast_ppf
+from spark_bestfit.fast_ppf import (
+    clear_ppf_cache,
+    fast_ppf,
+    fast_ppf_batch,
+    has_fast_ppf,
+)
 
 
 class TestFastPPFRegistry:
@@ -16,7 +21,15 @@ class TestFastPPFRegistry:
 
     def test_has_fast_ppf_supported_distributions(self):
         """Verify has_fast_ppf returns True for supported distributions."""
-        supported = ["norm", "expon", "uniform", "lognorm", "weibull_min", "gamma", "beta"]
+        supported = [
+            "norm",
+            "expon",
+            "uniform",
+            "lognorm",
+            "weibull_min",
+            "gamma",
+            "beta",
+        ]
         for dist in supported:
             assert has_fast_ppf(dist), f"{dist} should be supported"
 
@@ -423,3 +436,311 @@ class TestFastPPFPerformance:
         assert fast_time <= scipy_time * 1.2, (
             f"fast_ppf for gamma is too slow: {fast_time:.3f}s vs scipy {scipy_time:.3f}s"
         )
+
+
+class TestFastPPFParameterEdgeCases:
+    """Tests for edge cases with different parameter counts.
+
+    Each distribution function has branches for handling:
+    - Full parameters (all shape + loc + scale)
+    - Minimal parameters (shape only)
+    - Empty parameters (defaults)
+
+    These tests ensure all branches are exercised.
+    """
+
+    @pytest.fixture
+    def quantiles(self):
+        return np.array([0.1, 0.5, 0.9])
+
+    # Normal distribution parameter cases
+    def test_norm_no_params(self, quantiles):
+        """Test normal with empty params (defaults to loc=0, scale=1)."""
+        params = ()
+        result = fast_ppf("norm", params, quantiles)
+        expected = st.norm.ppf(quantiles, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_norm_one_param(self, quantiles):
+        """Test normal with one param (loc only, scale defaults to 1)."""
+        params = (5.0,)
+        result = fast_ppf("norm", params, quantiles)
+        expected = st.norm.ppf(quantiles, 5.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    # Exponential distribution parameter cases
+    def test_expon_no_params(self, quantiles):
+        """Test exponential with empty params (defaults to loc=0, scale=1)."""
+        params = ()
+        result = fast_ppf("expon", params, quantiles)
+        expected = st.expon.ppf(quantiles, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_expon_one_param(self, quantiles):
+        """Test exponential with one param (loc only)."""
+        params = (2.0,)
+        result = fast_ppf("expon", params, quantiles)
+        expected = st.expon.ppf(quantiles, 2.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    # Uniform distribution parameter cases
+    def test_uniform_no_params(self, quantiles):
+        """Test uniform with empty params (defaults to loc=0, scale=1)."""
+        params = ()
+        result = fast_ppf("uniform", params, quantiles)
+        expected = st.uniform.ppf(quantiles, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_uniform_one_param(self, quantiles):
+        """Test uniform with one param (loc only)."""
+        params = (10.0,)
+        result = fast_ppf("uniform", params, quantiles)
+        expected = st.uniform.ppf(quantiles, 10.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    # Lognormal distribution parameter cases
+    def test_lognorm_one_param(self, quantiles):
+        """Test lognormal with shape only (s=0.5, loc=0, scale=1)."""
+        params = (0.5,)
+        result = fast_ppf("lognorm", params, quantiles)
+        expected = st.lognorm.ppf(quantiles, 0.5, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_lognorm_two_params(self, quantiles):
+        """Test lognormal with shape and scale (s, scale), loc=0."""
+        params = (0.5, 2.0)  # s=0.5, scale=2.0
+        result = fast_ppf("lognorm", params, quantiles)
+        expected = st.lognorm.ppf(quantiles, 0.5, 0.0, 2.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    # Weibull minimum distribution parameter cases
+    def test_weibull_min_one_param(self, quantiles):
+        """Test Weibull with shape only (c=2, loc=0, scale=1)."""
+        params = (2.0,)
+        result = fast_ppf("weibull_min", params, quantiles)
+        expected = st.weibull_min.ppf(quantiles, 2.0, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_weibull_min_two_params(self, quantiles):
+        """Test Weibull with shape and scale (c, scale), loc=0."""
+        params = (1.5, 3.0)  # c=1.5, scale=3.0
+        result = fast_ppf("weibull_min", params, quantiles)
+        expected = st.weibull_min.ppf(quantiles, 1.5, 0.0, 3.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    # Gamma distribution parameter cases
+    def test_gamma_one_param(self, quantiles):
+        """Test gamma with shape only (a=2, loc=0, scale=1)."""
+        params = (2.0,)
+        result = fast_ppf("gamma", params, quantiles)
+        expected = st.gamma.ppf(quantiles, 2.0, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_gamma_two_params(self, quantiles):
+        """Test gamma with shape and scale (a, scale), loc=0."""
+        params = (2.0, 3.0)  # a=2.0, scale=3.0
+        result = fast_ppf("gamma", params, quantiles)
+        expected = st.gamma.ppf(quantiles, 2.0, 0.0, 3.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    # Beta distribution parameter cases
+    def test_beta_two_params(self, quantiles):
+        """Test beta with minimal params (a, b), defaults loc=0, scale=1."""
+        params = (2.0, 5.0)
+        result = fast_ppf("beta", params, quantiles)
+        expected = st.beta.ppf(quantiles, 2.0, 5.0, 0.0, 1.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_beta_three_params(self, quantiles):
+        """Test beta with (a, b, scale), loc=0."""
+        params = (2.0, 5.0, 10.0)  # a=2, b=5, scale=10
+        result = fast_ppf("beta", params, quantiles)
+        expected = st.beta.ppf(quantiles, 2.0, 5.0, 0.0, 10.0)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_beta_insufficient_params_raises(self):
+        """Test that beta with < 2 params raises ValueError."""
+        quantiles = np.array([0.5])
+        with pytest.raises(ValueError, match="at least 2 shape parameters"):
+            fast_ppf("beta", (2.0,), quantiles)
+
+
+class TestFastPPFCacheManagement:
+    """Tests for cache clearing functionality."""
+
+    def test_clear_ppf_cache(self):
+        """Test that clear_ppf_cache runs without error."""
+        # First populate the cache
+        quantiles = np.array([0.5])
+        fast_ppf("norm", (0.0, 1.0), quantiles, lb=0.0)
+        fast_ppf("norm", (0.0, 1.0), quantiles, lb=0.0, ub=1.0)
+
+        # Clear should not raise
+        clear_ppf_cache()
+
+        # Operations should still work after clearing
+        result = fast_ppf("norm", (0.0, 1.0), quantiles, lb=0.0)
+        assert len(result) == 1
+
+    def test_cache_hit_after_repeated_calls(self):
+        """Verify cache is being used for repeated calls."""
+        from spark_bestfit.fast_ppf import _cached_truncation_bounds
+
+        # Clear cache first
+        clear_ppf_cache()
+
+        # First call should be a miss
+        params = (0.0, 1.0)
+        _ = _cached_truncation_bounds("norm", params, 0.0, 1.0)
+        info = _cached_truncation_bounds.cache_info()
+        first_misses = info.misses
+
+        # Second call with same args should hit cache
+        _ = _cached_truncation_bounds("norm", params, 0.0, 1.0)
+        info = _cached_truncation_bounds.cache_info()
+        assert info.hits >= 1, "Cache should have at least one hit"
+        assert info.misses == first_misses, "No new cache misses expected"
+
+
+class TestFastPPFDegenerateTruncation:
+    """Tests for degenerate truncation cases."""
+
+    def test_truncation_zero_range(self):
+        """Test when lower and upper bounds are equal (degenerate case)."""
+        quantiles = np.array([0.1, 0.5, 0.9])
+        params = (0.0, 1.0)
+        lb = 0.5
+        ub = 0.5  # Same as lb - zero range
+
+        result = fast_ppf("norm", params, quantiles, lb=lb, ub=ub)
+
+        # With zero range, all quantiles should map to cdf_lb
+        # which means PPF should return values at that single CDF point
+        assert len(result) == 3
+        # All results should be identical since the range is degenerate
+        np.testing.assert_allclose(result, result[0] * np.ones(3), rtol=1e-10)
+
+    def test_truncation_inverted_bounds(self):
+        """Test when upper < lower (impossible range)."""
+        quantiles = np.array([0.5])
+        params = (0.0, 1.0)
+        lb = 1.0
+        ub = -1.0  # Upper below lower - degenerate
+
+        result = fast_ppf("norm", params, quantiles, lb=lb, ub=ub)
+
+        # Should handle gracefully without crashing
+        assert len(result) == 1
+
+    def test_truncation_with_infinite_bounds(self):
+        """Test truncation with explicit infinite bounds (should behave like no truncation)."""
+        quantiles = np.array([0.1, 0.5, 0.9])
+        params = (0.0, 1.0)
+
+        # Explicit infinities
+        result_inf = fast_ppf(
+            "norm", params, quantiles, lb=float("-inf"), ub=float("inf")
+        )
+        # No truncation
+        result_none = fast_ppf("norm", params, quantiles)
+
+        np.testing.assert_allclose(result_inf, result_none, rtol=1e-10)
+
+
+class TestFastPPFAdditionalTruncation:
+    """Additional truncation edge cases for full coverage."""
+
+    @pytest.fixture
+    def quantiles(self):
+        return np.array([0.1, 0.25, 0.5, 0.75, 0.9])
+
+    def test_truncated_gamma_both_bounds(self, quantiles):
+        """Test truncated gamma with both bounds."""
+        params = (2.0, 0.0, 1.0)  # a=2, loc=0, scale=1
+        lb = 0.5
+        ub = 5.0
+
+        frozen = st.gamma(*params)
+        cdf_lb = frozen.cdf(lb)
+        cdf_ub = frozen.cdf(ub)
+        norm = cdf_ub - cdf_lb
+        q_mapped = cdf_lb + quantiles * norm
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("gamma", params, quantiles, lb=lb, ub=ub)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_truncated_beta_both_bounds(self, quantiles):
+        """Test truncated beta with both bounds."""
+        params = (2.0, 5.0, 0.0, 1.0)  # a=2, b=5, loc=0, scale=1
+        lb = 0.1
+        ub = 0.8
+
+        frozen = st.beta(*params)
+        cdf_lb = frozen.cdf(lb)
+        cdf_ub = frozen.cdf(ub)
+        norm = cdf_ub - cdf_lb
+        q_mapped = cdf_lb + quantiles * norm
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("beta", params, quantiles, lb=lb, ub=ub)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_truncated_uniform_both_bounds(self, quantiles):
+        """Test truncated uniform with both bounds."""
+        params = (0.0, 10.0)  # loc=0, scale=10 -> [0, 10]
+        lb = 2.0
+        ub = 8.0
+
+        frozen = st.uniform(*params)
+        cdf_lb = frozen.cdf(lb)
+        cdf_ub = frozen.cdf(ub)
+        norm = cdf_ub - cdf_lb
+        q_mapped = cdf_lb + quantiles * norm
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("uniform", params, quantiles, lb=lb, ub=ub)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_truncated_lognorm_lower_only(self, quantiles):
+        """Test truncated lognormal with lower bound only."""
+        params = (0.5, 0.0, 1.0)  # s=0.5, loc=0, scale=1
+        lb = 0.5
+
+        frozen = st.lognorm(*params)
+        cdf_lb = frozen.cdf(lb)
+        q_mapped = cdf_lb + quantiles * (1.0 - cdf_lb)
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("lognorm", params, quantiles, lb=lb)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_truncated_weibull_upper_only(self, quantiles):
+        """Test truncated Weibull with upper bound only."""
+        params = (2.0, 0.0, 1.0)  # c=2, loc=0, scale=1
+        ub = 2.0
+
+        frozen = st.weibull_min(*params)
+        cdf_ub = frozen.cdf(ub)
+        q_mapped = quantiles * cdf_ub
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("weibull_min", params, quantiles, ub=ub)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_truncated_fallback_distribution(self, quantiles):
+        """Test truncation works with scipy fallback distributions."""
+        # Pareto is not in fast_ppf registry, will use scipy fallback
+        params = (2.0, 0.0, 1.0)  # shape, loc, scale
+        lb = 1.5
+        ub = 5.0
+
+        frozen = st.pareto(*params)
+        cdf_lb = frozen.cdf(lb)
+        cdf_ub = frozen.cdf(ub)
+        norm = cdf_ub - cdf_lb
+        q_mapped = cdf_lb + quantiles * norm
+        expected = frozen.ppf(q_mapped)
+
+        result = fast_ppf("pareto", params, quantiles, lb=lb, ub=ub)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)


### PR DESCRIPTION
## Summary
Add 26 new tests to increase fast_ppf.py test coverage from 63% to 92%.

## Related Issues
N/A

## Changes Made
- Add `TestFastPPFParameterEdgeCases` class (15 tests) - parameter variations for all distributions
- Add `TestFastPPFCacheManagement` class (2 tests) - cache clearing and hit verification
- Add `TestFastPPFDegenerateTruncation` class (3 tests) - edge cases for truncation
- Add `TestFastPPFAdditionalTruncation` class (6 tests) - truncation with all distributions
- Import `clear_ppf_cache` in test file

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] CI/CD or tooling changes

## Performance Impact
- [x] No performance impact expected
- [ ] Improves performance
- [ ] May impact performance (explain tradeoffs below)

## Testing
- [x] All existing tests pass (`make test`)
- [x] Added new tests for the changes
- [x] Tested manually with example code
- [ ] Ran benchmarks (`make benchmark`) - if performance-related
- [ ] Validated example notebooks (`make validate-notebooks`) - if API changes

## Checklist
- [x] My code follows the project's style guidelines (`make check`)
- [ ] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally