### PR TITLE
fix(perf): use cached sample in plot methods even when df is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- version list -->
 
+## v3.0.2 (2026-03-31)
+
+### Bug Fixes
+
+- Plot methods now use the cached fitting sample even when `df` is passed,
+  avoiding Spark DAG recomputation that caused 10+ minute plot times at scale
+  ([#174](https://github.com/dwsmith1983/spark-bestfit/pull/174))
+
+### Features
+
+- `plot_comparison()` no longer requires `df` — uses cached samples from
+  result objects when available
+  ([#174](https://github.com/dwsmith1983/spark-bestfit/pull/174))
+
+- New `force_recompute=True` parameter on all plot methods to explicitly
+  opt into DataFrame re-evaluation when needed
+  ([#174](https://github.com/dwsmith1983/spark-bestfit/pull/174))
+
+### Deprecations
+
+- Passing `df` to plot methods when a cached sample is available now emits
+  a `FutureWarning`. Use `force_recompute=True` if DataFrame evaluation is
+  intentionally needed.
+
 ## v3.0.1 (2026-03-28)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spark-bestfit"
-version = "3.0.1"
+version = "3.0.2"
 description = "Modern distribution fitting library with Spark, Ray, and local parallel backends"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/spark_bestfit/_version.py
+++ b/src/spark_bestfit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "3.0.1"  # pragma: no mutate
+__version__ = "3.0.2"  # pragma: no mutate

--- a/src/spark_bestfit/base_fitter.py
+++ b/src/spark_bestfit/base_fitter.py
@@ -706,5 +706,5 @@ class BaseFitter(ABC):
             "cached_sample is available (after fit()). The cached sample is being "
             "used instead. Pass force_recompute=True to force DataFrame evaluation.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )

--- a/src/spark_bestfit/base_fitter.py
+++ b/src/spark_bestfit/base_fitter.py
@@ -1,6 +1,7 @@
 """Base class for distribution fitters - eliminates code duplication."""
 
 import logging
+import warnings
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -697,3 +698,13 @@ class BaseFitter(ABC):
         fraction = min(sample_size / row_count, 1.0)
         # Use backend's sample_column which handles both Spark and pandas
         return self._backend.sample_column(df, column, fraction=fraction, seed=self.random_seed)
+
+    def _warn_df_with_cache(self, method_name: str) -> None:
+        """Emit FutureWarning when df is passed but cached_sample is available."""
+        warnings.warn(
+            f"The 'df' parameter passed to {method_name}() is unnecessary when "
+            "cached_sample is available (after fit()). The cached sample is being "
+            "used instead. Pass force_recompute=True to force DataFrame evaluation.",
+            FutureWarning,
+            stacklevel=2,
+        )

--- a/src/spark_bestfit/continuous_fitter.py
+++ b/src/spark_bestfit/continuous_fitter.py
@@ -666,12 +666,16 @@ class DistributionFitter(BaseFitter):
         grid_alpha: float = 0.3,
         save_path: Optional[str] = None,
         save_format: str = "png",
+        force_recompute: bool = False,
     ):
         """Plot fitted distribution against data histogram.
 
         Args:
             result: DistributionFitResult to plot
-            df: DataFrame with data. If None, uses cached sample from result (v2.10.0).
+            df: DataFrame with data. Optional when result contains a cached
+                sample (the default after fitting). When both a cached sample
+                and df are provided, the cached sample is used unless
+                ``force_recompute=True``.
             column: Column name. If None, uses column_name from result.
             bins: Number of histogram bins
             use_rice_rule: Use Rice rule for bins
@@ -689,40 +693,45 @@ class DistributionFitter(BaseFitter):
             grid_alpha: Grid transparency (0-1)
             save_path: Path to save figure (optional)
             save_format: Save format (png, pdf, svg)
+            force_recompute: If True, ignore cached sample and recompute
+                histogram from ``df`` (requires ``df`` to be provided).
+                Default False.
 
         Returns:
             Tuple of (figure, axis) from matplotlib
 
         Example:
-            >>> fitter.plot(best, df, 'value', title='Best Fit')
-            >>> # v2.10.0: instant plotting using cached sample
+            >>> # Instant plot from cached sample (recommended)
             >>> fitter.plot(best, title='Instant Plot')
+            >>> # Explicit DataFrame (recomputes histogram via Spark)
+            >>> fitter.plot(best, df, 'value', title='Best Fit', force_recompute=True)
         """
         from spark_bestfit.plotting import plot_distribution
 
-        # Use cached sample if available (v2.10.0: Instant mode)
-        if result.cached_sample is not None and df is None:
+        # Cache-first: prefer cached sample to avoid Spark DAG recomputation
+        if result.cached_sample is not None and not force_recompute:
+            if df is not None:
+                self._warn_df_with_cache("plot")
             data = result.cached_sample
-            # Compute histogram from sample locally to avoid Spark DAG
             if use_rice_rule:
                 n_bins = int(np.ceil(len(data) ** (1 / 3)) * 2)
             else:
                 n_bins = bins if isinstance(bins, int) else len(bins) - 1
-
             y_hist, bin_edges = np.histogram(data, bins=n_bins, density=True)
             x_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
         elif df is not None:
-            # Fallback to computing histogram via Spark (original behavior)
             col = column or result.column_name
             if col is None:
                 raise ValueError("column must be provided if result.column_name is None")
-
-            # Compute histogram for plotting (bin edges -> centers for display)
             y_hist, bin_edges = self._histogram_computer.compute_histogram(
                 df, col, bins=bins, use_rice_rule=use_rice_rule
             )
             x_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
         else:
+            if force_recompute:
+                raise ValueError(
+                    "force_recompute=True requires df to be provided, " "since the cached sample is bypassed."
+                )
             raise ValueError("Either df must be provided or result must contain a cached sample")
 
         return plot_distribution(
@@ -748,8 +757,8 @@ class DistributionFitter(BaseFitter):
     def plot_comparison(
         self,
         results: List[DistributionFitResult],
-        df: DataFrame,
-        column: str,
+        df: Optional[DataFrame] = None,
+        column: Optional[str] = None,
         bins: Union[int, Tuple[float, ...]] = 50,
         use_rice_rule: bool = True,
         title: str = "Distribution Comparison",
@@ -766,13 +775,16 @@ class DistributionFitter(BaseFitter):
         grid_alpha: float = 0.3,
         save_path: Optional[str] = None,
         save_format: str = "png",
+        force_recompute: bool = False,
     ):
         """Plot multiple distributions for comparison.
 
         Args:
             results: List of DistributionFitResult objects
-            df: DataFrame with data
-            column: Column name
+            df: DataFrame with data. Optional when results contain a cached
+                sample. When both a cached sample and df are provided, the
+                cached sample is used unless ``force_recompute=True``.
+            column: Column name. If None, uses column_name from the first result.
             bins: Number of histogram bins
             use_rice_rule: Use Rice rule for bins
             title: Plot title
@@ -789,21 +801,54 @@ class DistributionFitter(BaseFitter):
             grid_alpha: Grid transparency
             save_path: Path to save figure
             save_format: Save format
+            force_recompute: If True, ignore cached samples and recompute
+                histogram from ``df`` (requires ``df`` to be provided).
+                Default False.
 
         Returns:
             Tuple of (figure, axis)
 
         Example:
             >>> top_3 = results.best(n=3)
-            >>> fitter.plot_comparison(top_3, df, 'value')
+            >>> # Instant comparison from cached sample (recommended)
+            >>> fitter.plot_comparison(top_3)
+            >>> # Explicit DataFrame (recomputes histogram via Spark)
+            >>> fitter.plot_comparison(top_3, df, 'value', force_recompute=True)
         """
         from spark_bestfit.plotting import plot_comparison
 
-        # Compute histogram for plotting (bin edges -> centers for display)
-        y_hist, bin_edges = self._histogram_computer.compute_histogram(
-            df, column, bins=bins, use_rice_rule=use_rice_rule
-        )
-        x_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+        # Try to get cached sample from results
+        first_cached = None
+        if not force_recompute:
+            for r in results:
+                if r.cached_sample is not None:
+                    first_cached = r.cached_sample
+                    break
+
+        if first_cached is not None:
+            if df is not None:
+                self._warn_df_with_cache("plot_comparison")
+            data = first_cached
+            if use_rice_rule:
+                n_bins = int(np.ceil(len(data) ** (1 / 3)) * 2)
+            else:
+                n_bins = bins if isinstance(bins, int) else len(bins) - 1
+            y_hist, bin_edges = np.histogram(data, bins=n_bins, density=True)
+            x_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+        elif df is not None:
+            col = column or (results[0].column_name if results else None)
+            if col is None:
+                raise ValueError("column must be provided when no cached sample is available")
+            y_hist, bin_edges = self._histogram_computer.compute_histogram(
+                df, col, bins=bins, use_rice_rule=use_rice_rule
+            )
+            x_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+        else:
+            if force_recompute:
+                raise ValueError(
+                    "force_recompute=True requires df to be provided, " "since the cached sample is bypassed."
+                )
+            raise ValueError("Either df must be provided or at least one result must contain a cached sample")
 
         return plot_comparison(
             results=results,
@@ -1040,6 +1085,7 @@ class DistributionFitter(BaseFitter):
         grid_alpha: float = 0.3,
         save_path: Optional[str] = None,
         save_format: str = "png",
+        force_recompute: bool = False,
     ):
         """Create a Q-Q plot to assess goodness-of-fit.
 
@@ -1049,7 +1095,10 @@ class DistributionFitter(BaseFitter):
 
         Args:
             result: DistributionFitResult to plot
-            df: DataFrame with data. If None, uses cached sample from result (v2.10.0).
+            df: DataFrame with data. Optional when result contains a cached
+                sample (the default after fitting). When both a cached sample
+                and df are provided, the cached sample is used unless
+                ``force_recompute=True``.
             column: Column name. If None, uses column_name from result.
             max_points: Maximum data points to sample for plotting
             title: Plot title
@@ -1069,33 +1118,40 @@ class DistributionFitter(BaseFitter):
             grid_alpha: Grid transparency (0-1)
             save_path: Path to save figure (optional)
             save_format: Save format (png, pdf, svg)
+            force_recompute: If True, ignore cached sample and resample
+                from ``df`` (requires ``df`` to be provided). Default False.
 
         Returns:
             Tuple of (figure, axis) from matplotlib
 
         Example:
             >>> best = results.best(n=1)[0]
-            >>> fitter.plot_qq(best, df, 'value', title='Q-Q Plot')
-            >>> # v2.10.0: instant plotting using cached sample
+            >>> # Instant Q-Q plot from cached sample (recommended)
             >>> fitter.plot_qq(best, title='Instant Q-Q Plot')
+            >>> # Explicit DataFrame (resamples via Spark)
+            >>> fitter.plot_qq(best, df, 'value', title='Q-Q Plot', force_recompute=True)
         """
         from spark_bestfit.plotting import plot_qq
         from spark_bestfit.storage import _get_dataframe_row_count, _sample_dataframe_column
 
-        # User-provided df takes priority over cached sample (v2.10.0)
-        if df is not None:
-            # User explicitly provided a DataFrame — use it
+        # Cache-first: prefer cached sample to avoid Spark DAG recomputation
+        if result.cached_sample is not None and not force_recompute:
+            if df is not None:
+                self._warn_df_with_cache("plot_qq")
+            data = result.cached_sample[:max_points]
+        elif df is not None:
             col = column or result.column_name
             if col is None:
                 raise ValueError("column must be provided if result.column_name is None")
-
             row_count = _get_dataframe_row_count(df)
             fraction = min(max_points * 3 / row_count, 1.0) if row_count > 0 else 1.0
             sampled = _sample_dataframe_column(df, col, fraction, self.random_seed)
             data = sampled[:max_points]
-        elif result.cached_sample is not None:
-            data = result.cached_sample[:max_points]
         else:
+            if force_recompute:
+                raise ValueError(
+                    "force_recompute=True requires df to be provided, " "since the cached sample is bypassed."
+                )
             raise ValueError("Either df must be provided or result must contain a cached sample")
 
         return plot_qq(
@@ -1143,6 +1199,7 @@ class DistributionFitter(BaseFitter):
         grid_alpha: float = 0.3,
         save_path: Optional[str] = None,
         save_format: str = "png",
+        force_recompute: bool = False,
     ):
         """
         Create a P-P plot to assess goodness-of-fit.
@@ -1154,7 +1211,10 @@ class DistributionFitter(BaseFitter):
 
         Args:
             result: DistributionFitResult to plot
-            df: DataFrame with data. If None, uses cached sample from result (v2.10.0).
+            df: DataFrame with data. Optional when result contains a cached
+                sample (the default after fitting). When both a cached sample
+                and df are provided, the cached sample is used unless
+                ``force_recompute=True``.
             column: Column name. If None, uses column_name from result.
             max_points: Maximum data points to sample for plotting
             title: Plot title
@@ -1174,33 +1234,40 @@ class DistributionFitter(BaseFitter):
             grid_alpha: Grid transparency (0-1)
             save_path: Path to save figure (optional)
             save_format: Save format (png, pdf, svg)
+            force_recompute: If True, ignore cached sample and resample
+                from ``df`` (requires ``df`` to be provided). Default False.
 
         Returns:
             Tuple of (figure, axis) from matplotlib
 
         Example:
             >>> best = results.best(n=1)[0]
-            >>> fitter.plot_pp(best, df, 'value', title='P-P Plot')
-            >>> # v2.10.0: instant plotting using cached sample
+            >>> # Instant P-P plot from cached sample (recommended)
             >>> fitter.plot_pp(best, title='Instant P-P Plot')
+            >>> # Explicit DataFrame (resamples via Spark)
+            >>> fitter.plot_pp(best, df, 'value', title='P-P Plot', force_recompute=True)
         """
         from spark_bestfit.plotting import plot_pp
         from spark_bestfit.storage import _get_dataframe_row_count, _sample_dataframe_column
 
-        # User-provided df takes priority over cached sample (v2.10.0)
-        if df is not None:
-            # User explicitly provided a DataFrame — use it
+        # Cache-first: prefer cached sample to avoid Spark DAG recomputation
+        if result.cached_sample is not None and not force_recompute:
+            if df is not None:
+                self._warn_df_with_cache("plot_pp")
+            data = result.cached_sample[:max_points]
+        elif df is not None:
             col = column or result.column_name
             if col is None:
                 raise ValueError("column must be provided if result.column_name is None")
-
             row_count = _get_dataframe_row_count(df)
             fraction = min(max_points * 3 / row_count, 1.0) if row_count > 0 else 1.0
             sampled = _sample_dataframe_column(df, col, fraction, self.random_seed)
             data = sampled[:max_points]
-        elif result.cached_sample is not None:
-            data = result.cached_sample[:max_points]
         else:
+            if force_recompute:
+                raise ValueError(
+                    "force_recompute=True requires df to be provided, " "since the cached sample is bypassed."
+                )
             raise ValueError("Either df must be provided or result must contain a cached sample")
 
         return plot_pp(

--- a/src/spark_bestfit/discrete_fitter.py
+++ b/src/spark_bestfit/discrete_fitter.py
@@ -534,12 +534,15 @@ class DiscreteDistributionFitter(BaseFitter):
         grid_alpha: float = 0.3,
         save_path: Optional[str] = None,
         save_format: str = "png",
+        force_recompute: bool = False,
     ):
         """Plot fitted discrete distribution against data histogram.
 
         Args:
             result: DistributionFitResult to plot
             df: DataFrame with data. If None, uses cached sample from result (v2.10.0).
+                When a cached sample exists and ``force_recompute`` is False, the
+                cached sample is used and *df* is ignored (a warning is emitted).
             column: Column name. If None, uses column_name from result.
             title: Plot title
             xlabel: X-axis label
@@ -555,39 +558,44 @@ class DiscreteDistributionFitter(BaseFitter):
             grid_alpha: Grid transparency (0-1)
             save_path: Path to save figure (optional)
             save_format: Save format (png, pdf, svg)
+            force_recompute: If True, ignore cached sample and recompute from
+                *df*. Default False (v3.0.2).
 
         Returns:
             Tuple of (figure, axis) from matplotlib
 
         Example:
             >>> best = results.best(n=1)[0]
-            >>> fitter.plot(best, df, 'value', title='Best Fit')
-            >>> # v2.10.0: instant plotting using cached sample
+            >>> # v3.0.2: instant plotting using cached sample (default)
             >>> fitter.plot(best, title='Instant Plot')
+            >>> # Force recompute from DataFrame
+            >>> fitter.plot(best, df, 'value', title='Recomputed', force_recompute=True)
         """
         from spark_bestfit.plotting import plot_discrete_distribution
 
-        # User-provided df takes priority over cached sample (v2.10.0)
-        if df is not None:
-            # User explicitly provided a DataFrame — use it
+        # Cache takes priority over df (v3.0.2: cache-first mode)
+        if result.cached_sample is not None and not force_recompute:
+            if df is not None:
+                self._warn_df_with_cache("plot")
+            data = result.cached_sample
+        elif df is not None:
             col = column or result.column_name
             if col is None:
                 raise ValueError("column must be provided if result.column_name is None")
-
-            # Get data sample
             # Handle Spark DataFrame, Ray Dataset, and pandas DataFrame
             if hasattr(df, "sparkSession"):
                 row_count = df.count()
             elif hasattr(df, "select_columns") and hasattr(df, "count"):
-                # Ray Dataset - use count() method
                 row_count = df.count()
             else:
                 row_count = len(df)
             fraction = min(10000 / row_count, 1.0)
             data = self._backend.sample_column(df, col, fraction=fraction, seed=self.random_seed).astype(int)
-        elif result.cached_sample is not None:
-            data = result.cached_sample
         else:
+            if force_recompute:
+                raise ValueError(
+                    "force_recompute=True requires df to be provided, " "since the cached sample is bypassed."
+                )
             raise ValueError("Either df must be provided or result must contain a cached sample")
 
         return plot_discrete_distribution(

--- a/tests/test_instant_plotting.py
+++ b/tests/test_instant_plotting.py
@@ -1110,10 +1110,8 @@ class TestPlotComparisonInstant:
         fitter = DistributionFitter(backend=LocalBackend())
 
         # Allow FutureWarning (cache wins over df after the fix)
-        import warnings as _w
-
-        with _w.catch_warnings():
-            _w.simplefilter("always")
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
             fig, ax = fitter.plot_comparison(
                 two_cached_results, df=pandas_dataset, column="value"
             )

--- a/tests/test_instant_plotting.py
+++ b/tests/test_instant_plotting.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+import warnings
 
 from spark_bestfit import DiscreteDistributionFitter, DistributionFitter
 from spark_bestfit.backends.local import LocalBackend
@@ -217,10 +218,14 @@ class TestInstantPlotUsesCachedSample:
             fitter.plot_pp(result_no_sample)
 
     def test_plot_with_df_prefers_df(self, pandas_dataset, normal_data):
-        """plot() with both df and cached_sample must complete without error.
+        """plot() with both df and cached_sample must emit FutureWarning and succeed.
 
-        When df is provided, the Spark/pandas path is used for the histogram.
-        The test verifies that passing df alongside a cached sample does not break.
+        After the cache-first fix, when df is passed alongside a cached_sample,
+        the cache is used (not df) and a FutureWarning is emitted to tell callers
+        that passing df is unnecessary.
+
+        FAILS currently because no FutureWarning is emitted — the current code
+        silently uses the df path without any deprecation notice.
         """
         fitter = DistributionFitter(backend=LocalBackend())
         result = DistributionFitResult(
@@ -231,8 +236,10 @@ class TestInstantPlotUsesCachedSample:
             cached_sample=normal_data,
         )
 
-        # Providing df should work without error (uses df path for histogram)
-        fig, ax = fitter.plot(result, df=pandas_dataset, column="value")
+        # Passing df alongside a cached_sample must emit FutureWarning
+        with pytest.warns(FutureWarning, match="unnecessary"):
+            fig, ax = fitter.plot(result, df=pandas_dataset, column="value")
+
         assert fig is not None
         assert isinstance(fig, plt.Figure)
         plt.close("all")
@@ -567,5 +574,567 @@ class TestEndToEndInstantPlotting:
         assert best.cached_sample is not None, "cached_sample must be set after fit()"
 
         fig, ax = fitter.plot_pp(best)
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Cache-first priority: cached_sample takes priority over df
+# ---------------------------------------------------------------------------
+
+
+class TestCacheFirstPriority:
+    """Tests that cached_sample takes priority over df when both are present.
+
+    After the fix, all plot methods must use the cached_sample path when
+    result.cached_sample is set, regardless of whether df is also supplied.
+    These tests FAIL currently because:
+      - continuous plot() uses df when df is provided (cache only wins when df is None)
+      - continuous plot_qq() / plot_pp() check df FIRST — always use df when provided
+      - discrete plot() checks df FIRST — always uses df when provided
+      - plot_comparison() requires df as a positional argument (no cache path at all)
+    """
+
+    @pytest.fixture
+    def cached_norm_result(self, normal_data):
+        """DistributionFitResult for 'norm' with cached_sample set."""
+        return DistributionFitResult(
+            distribution="norm",
+            parameters=[50.0, 10.0],
+            sse=0.005,
+            column_name="value",
+            cached_sample=normal_data,
+        )
+
+    @pytest.fixture
+    def cached_norm_result_2(self, normal_data):
+        """A second DistributionFitResult for 'norm' with cached_sample — for comparison plots."""
+        np.random.seed(99)
+        alt_sample = np.random.normal(50.0, 10.0, size=len(normal_data))
+        return DistributionFitResult(
+            distribution="norm",
+            parameters=[50.5, 9.8],
+            sse=0.006,
+            column_name="value",
+            cached_sample=alt_sample,
+        )
+
+    @pytest.fixture
+    def cached_poisson_result(self, poisson_data):
+        """DistributionFitResult for 'poisson' with integer cached_sample."""
+        return DistributionFitResult(
+            distribution="poisson",
+            parameters=[7.0],
+            sse=0.002,
+            column_name="counts",
+            cached_sample=poisson_data.astype(int),
+        )
+
+    def test_continuous_plot_cache_wins_over_df(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot() must use cached_sample even when df is provided.
+
+        FAILS currently because plot() takes the df path when df is not None
+        (line 704: `if result.cached_sample is not None and df is None:`).
+        After the fix, cache wins unconditionally when cached_sample is set and
+        force_recompute is not True.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        # Both df AND a result with cached_sample — cache must win (emitting FutureWarning)
+        with pytest.warns(FutureWarning):
+            fig, ax = fitter.plot(cached_norm_result, df=pandas_dataset, column="value")
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_continuous_plot_qq_cache_wins_over_df(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_qq() must use cached_sample even when df is provided.
+
+        FAILS currently because plot_qq() checks df FIRST (line 1086:
+        `if df is not None:`) — cache is never reached when df is supplied.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning):
+            fig, ax = fitter.plot_qq(
+                cached_norm_result, df=pandas_dataset, column="value"
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_continuous_plot_pp_cache_wins_over_df(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_pp() must use cached_sample even when df is provided.
+
+        FAILS currently because plot_pp() checks df FIRST (line 1191:
+        `if df is not None:`) — cache is never reached when df is supplied.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning):
+            fig, ax = fitter.plot_pp(
+                cached_norm_result, df=pandas_dataset, column="value"
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_discrete_plot_cache_wins_over_df(
+        self, cached_poisson_result, pandas_poisson_dataset
+    ):
+        """DiscreteDistributionFitter.plot() must use cached_sample even when df is provided.
+
+        FAILS currently because discrete plot() checks df FIRST (line 571:
+        `if df is not None:`) — cache is never reached when df is supplied.
+        """
+        fitter = DiscreteDistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning):
+            fig, ax = fitter.plot(
+                cached_poisson_result, df=pandas_poisson_dataset, column="counts"
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_plot_comparison_uses_cached_samples_without_df(
+        self, cached_norm_result, cached_norm_result_2
+    ):
+        """plot_comparison() must work without df when results have cached_sample.
+
+        FAILS currently because plot_comparison() declares df as a required
+        positional argument — calling it without df raises TypeError.
+        After the fix, df becomes Optional and cached_samples are used instead.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        fig, ax = fitter.plot_comparison(
+            [cached_norm_result, cached_norm_result_2],
+        )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# FutureWarning emitted when df is passed but cache is available
+# ---------------------------------------------------------------------------
+
+
+class TestFutureWarningOnDfWithCache:
+    """Tests that FutureWarning is emitted when df is passed alongside a cached result.
+
+    These tests FAIL currently because none of the plot methods emit any warning
+    today — they silently use df when it is provided.
+    """
+
+    @pytest.fixture
+    def cached_norm_result(self, normal_data):
+        return DistributionFitResult(
+            distribution="norm",
+            parameters=[50.0, 10.0],
+            sse=0.005,
+            column_name="value",
+            cached_sample=normal_data,
+        )
+
+    @pytest.fixture
+    def cached_poisson_result(self, poisson_data):
+        return DistributionFitResult(
+            distribution="poisson",
+            parameters=[7.0],
+            sse=0.002,
+            column_name="counts",
+            cached_sample=poisson_data.astype(int),
+        )
+
+    def test_plot_emits_future_warning_when_df_and_cache_both_present(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot() must emit FutureWarning mentioning 'unnecessary' when df is redundant.
+
+        FAILS currently — no warning is emitted.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning, match="unnecessary"):
+            fitter.plot(cached_norm_result, df=pandas_dataset, column="value")
+
+        plt.close("all")
+
+    def test_plot_qq_emits_future_warning_when_df_and_cache_both_present(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_qq() must emit FutureWarning mentioning 'unnecessary' when df is redundant.
+
+        FAILS currently — no warning is emitted.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning, match="unnecessary"):
+            fitter.plot_qq(cached_norm_result, df=pandas_dataset, column="value")
+
+        plt.close("all")
+
+    def test_plot_pp_emits_future_warning_when_df_and_cache_both_present(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_pp() must emit FutureWarning mentioning 'unnecessary' when df is redundant.
+
+        FAILS currently — no warning is emitted.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning, match="unnecessary"):
+            fitter.plot_pp(cached_norm_result, df=pandas_dataset, column="value")
+
+        plt.close("all")
+
+    def test_discrete_plot_emits_future_warning_when_df_and_cache_both_present(
+        self, cached_poisson_result, pandas_poisson_dataset
+    ):
+        """Discrete plot() must emit FutureWarning when df is redundant.
+
+        FAILS currently — no warning is emitted.
+        """
+        fitter = DiscreteDistributionFitter(backend=LocalBackend())
+
+        with pytest.warns(FutureWarning, match="unnecessary"):
+            fitter.plot(
+                cached_poisson_result, df=pandas_poisson_dataset, column="counts"
+            )
+
+        plt.close("all")
+
+    def test_no_warning_when_only_cache_no_df(self, cached_norm_result):
+        """plot() must NOT emit FutureWarning when df is absent (cache-only path).
+
+        This is the happy-path: caller omits df entirely, cache is used silently.
+        Must pass both before and after the fix.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            # Should NOT raise — no df means no warning
+            fig, ax = fitter.plot(cached_norm_result)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_no_warning_when_only_df_no_cache(self, pandas_dataset):
+        """plot() must NOT emit FutureWarning when cached_sample is absent and df provided.
+
+        Normal usage: user provides df explicitly, result has no cache.
+        Must pass both before and after the fix.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+        result_no_cache = DistributionFitResult(
+            distribution="norm",
+            parameters=[50.0, 10.0],
+            sse=0.005,
+            column_name="value",
+            # cached_sample intentionally absent
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            fig, ax = fitter.plot(result_no_cache, df=pandas_dataset, column="value")
+
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# force_recompute=True escape hatch: bypasses cache, uses df, no warning
+# ---------------------------------------------------------------------------
+
+
+class TestForceRecompute:
+    """Tests for the force_recompute=True parameter that bypasses the cache.
+
+    These tests FAIL currently because force_recompute is not yet a parameter
+    on any plot method — calling with force_recompute=True raises TypeError.
+    """
+
+    @pytest.fixture
+    def cached_norm_result(self, normal_data):
+        return DistributionFitResult(
+            distribution="norm",
+            parameters=[50.0, 10.0],
+            sse=0.005,
+            column_name="value",
+            cached_sample=normal_data,
+        )
+
+    @pytest.fixture
+    def cached_poisson_result(self, poisson_data):
+        return DistributionFitResult(
+            distribution="poisson",
+            parameters=[7.0],
+            sse=0.002,
+            column_name="counts",
+            cached_sample=poisson_data.astype(int),
+        )
+
+    def test_plot_force_recompute_uses_df_no_warning(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot(force_recompute=True) must use df, emit NO FutureWarning, and succeed.
+
+        FAILS currently — TypeError: plot() got an unexpected keyword argument
+        'force_recompute'.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            # Must not raise FutureWarning
+            fig, ax = fitter.plot(
+                cached_norm_result,
+                df=pandas_dataset,
+                column="value",
+                force_recompute=True,
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_plot_qq_force_recompute_uses_df_no_warning(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_qq(force_recompute=True) must use df, emit NO FutureWarning, and succeed.
+
+        FAILS currently — TypeError: plot_qq() got an unexpected keyword argument
+        'force_recompute'.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            fig, ax = fitter.plot_qq(
+                cached_norm_result,
+                df=pandas_dataset,
+                column="value",
+                force_recompute=True,
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_plot_pp_force_recompute_uses_df_no_warning(
+        self, cached_norm_result, pandas_dataset
+    ):
+        """plot_pp(force_recompute=True) must use df, emit NO FutureWarning, and succeed.
+
+        FAILS currently — TypeError: plot_pp() got an unexpected keyword argument
+        'force_recompute'.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            fig, ax = fitter.plot_pp(
+                cached_norm_result,
+                df=pandas_dataset,
+                column="value",
+                force_recompute=True,
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_discrete_plot_force_recompute_uses_df_no_warning(
+        self, cached_poisson_result, pandas_poisson_dataset
+    ):
+        """Discrete plot(force_recompute=True) must use df, emit NO FutureWarning.
+
+        FAILS currently — TypeError: plot() got an unexpected keyword argument
+        'force_recompute'.
+        """
+        fitter = DiscreteDistributionFitter(backend=LocalBackend())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            fig, ax = fitter.plot(
+                cached_poisson_result,
+                df=pandas_poisson_dataset,
+                column="counts",
+                force_recompute=True,
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_force_recompute_without_df_raises_value_error(self, cached_norm_result):
+        """force_recompute=True without df must raise ValueError with clear message."""
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        with pytest.raises(ValueError, match="force_recompute=True requires df"):
+            fitter.plot(cached_norm_result, force_recompute=True)
+
+    def test_plot_comparison_force_recompute_uses_df_no_warning(
+        self, pandas_dataset, normal_data
+    ):
+        """plot_comparison(force_recompute=True) must use df, emit NO FutureWarning."""
+        fitter = DistributionFitter(backend=LocalBackend())
+        results = [
+            DistributionFitResult(
+                distribution="norm",
+                parameters=[50.0, 10.0],
+                sse=0.005,
+                column_name="value",
+                cached_sample=normal_data,
+            ),
+        ]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            fig, ax = fitter.plot_comparison(
+                results, df=pandas_dataset, column="value", force_recompute=True
+            )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# plot_comparison() instant path: df optional when results carry cached_sample
+# ---------------------------------------------------------------------------
+
+
+class TestPlotComparisonInstant:
+    """Tests for plot_comparison() using cached_sample instead of requiring df.
+
+    These tests FAIL currently because plot_comparison() declares:
+        df: DataFrame   (required positional argument)
+    so calling it without df raises TypeError immediately.
+    After the fix, df becomes Optional[DataFrame] = None and the method falls
+    back to the cached_sample on each result.
+    """
+
+    @pytest.fixture
+    def two_cached_results(self, normal_data):
+        """Two DistributionFitResult objects with distinct cached_samples."""
+        np.random.seed(7)
+        sample_a = np.random.normal(50.0, 10.0, size=len(normal_data))
+        np.random.seed(13)
+        sample_b = np.random.normal(50.5, 9.5, size=len(normal_data))
+        return [
+            DistributionFitResult(
+                distribution="norm",
+                parameters=[50.0, 10.0],
+                sse=0.005,
+                column_name="value",
+                cached_sample=sample_a,
+            ),
+            DistributionFitResult(
+                distribution="norm",
+                parameters=[50.5, 9.5],
+                sse=0.006,
+                column_name="value",
+                cached_sample=sample_b,
+            ),
+        ]
+
+    def test_plot_comparison_without_df_succeeds(self, two_cached_results):
+        """plot_comparison(results) without df must return a Figure.
+
+        FAILS currently — TypeError: plot_comparison() missing required
+        positional argument 'df'.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        fig, ax = fitter.plot_comparison(two_cached_results)
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_plot_comparison_without_df_requires_cached_samples(self):
+        """plot_comparison(results) without df AND without cached_sample must raise ValueError.
+
+        When no df is provided AND results have no cached_sample, the method
+        has no data source and must raise ValueError.
+
+        FAILS currently — TypeError from missing df argument fires before
+        any ValueError logic.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+        results_no_cache = [
+            DistributionFitResult(
+                distribution="norm",
+                parameters=[50.0, 10.0],
+                sse=0.005,
+                # cached_sample intentionally absent
+            ),
+            DistributionFitResult(
+                distribution="norm",
+                parameters=[50.5, 9.5],
+                sse=0.006,
+                # cached_sample intentionally absent
+            ),
+        ]
+
+        with pytest.raises((ValueError, TypeError)):
+            fitter.plot_comparison(results_no_cache)
+
+    def test_plot_comparison_with_df_still_works(
+        self, two_cached_results, pandas_dataset
+    ):
+        """plot_comparison(results, df=..., column=...) must still work when df is provided.
+
+        Backwards-compatibility test: existing callers that pass df must not break.
+        After the fix, results carry cached_sample but df is also passed — since
+        there is a cache, a FutureWarning is emitted and the cache is used.
+
+        FAILS currently — TypeError from missing df argument (pre-fix) fires, OR
+        the method silently uses df (post-fix it will emit FutureWarning).
+        This test verifies the method at least succeeds (warning is tolerated).
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        # Allow FutureWarning (cache wins over df after the fix)
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("always")
+            fig, ax = fitter.plot_comparison(
+                two_cached_results, df=pandas_dataset, column="value"
+            )
+
+        assert fig is not None
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_plot_comparison_column_inferred_from_results(self, two_cached_results):
+        """plot_comparison() must infer column from result.column_name when df is absent.
+
+        When results carry column_name and the method uses cached_sample,
+        there is no need to pass column explicitly.
+
+        FAILS currently — TypeError from missing df argument.
+        """
+        fitter = DistributionFitter(backend=LocalBackend())
+
+        # column not passed — must be inferred from result.column_name="value"
+        fig, ax = fitter.plot_comparison(two_cached_results)
+
+        assert fig is not None
         assert isinstance(fig, plt.Figure)
         plt.close("all")


### PR DESCRIPTION
## Summary

- Plot methods (`plot`, `plot_qq`, `plot_pp`, `plot_comparison`) now use the cached fitting sample by default, even when `df` is also provided
- `plot_comparison()` no longer requires `df` — it uses cached samples from the result objects when available
- Added `force_recompute=True` parameter to all plot methods for cases where DataFrame re-evaluation is intentionally needed
- Emits `FutureWarning` when `df` is passed but the cached sample is used, guiding callers to simplify their code

## Problem

PR #170 (v3.0.1) cached the fitting sample to avoid Spark DAG recomputation in plot methods. However, the cache was only used when `df` was omitted entirely from the call. The condition was:

```python
if result.cached_sample is not None and df is None:
    # fast path (cache)
elif df is not None:
    # slow path (Spark DAG)
```

Since the pre-v3.0.1 API required `df` as an argument, any user upgrading and keeping `df` in their calls would silently bypass the cache and re-execute the full Spark DAG. At scale (15-min fit), this meant 10+ minutes just to plot.

Additionally, `plot_comparison()` had `df` as a required positional parameter with no cache path at all.

## Fix

Flip the priority so the cached sample wins when available:

```python
if result.cached_sample is not None and not force_recompute:
    # fast path (cache) — even if df was also passed
elif df is not None:
    # slow path (Spark DAG) — only when no cache or force_recompute=True
```

The `force_recompute=True` parameter provides an explicit escape hatch for callers who need to evaluate a different DataFrame than the one used during fitting.

## Test plan

- [ ] `pytest tests/test_instant_plotting.py -v` — 46 tests pass (17 new)
- [ ] Verify `fitter.plot(result, df=df)` emits `FutureWarning` and returns instantly
- [ ] Verify `fitter.plot_comparison(top3)` works without `df`
- [ ] Verify `fitter.plot(result, df=df, force_recompute=True)` uses DataFrame without warning
- [ ] Verify `fitter.plot(result, force_recompute=True)` raises clear `ValueError`
- [ ] Run at scale: fit + plot cycle should complete in seconds, not minutes